### PR TITLE
refactor(Trial): A config is now always assumed to be a mapping

### DIFF
--- a/src/byop/configuring/configurers/configspace.py
+++ b/src/byop/configuring/configurers/configspace.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
     from ConfigSpace import Configuration
 
 
-class ConfigSpaceConfigurer(Configurer["Configuration", str]):
-    """A Configurer that uses a ConfigSpace::Configuration to configure a pipeline."""
+class ConfigSpaceConfigurer(Configurer[str]):
+    """A Configurer that uses a configure a pipeline."""
 
     @classmethod
     def _configure(

--- a/src/byop/configuring/configurers/configurer.py
+++ b/src/byop/configuring/configurers/configurer.py
@@ -14,7 +14,7 @@ class ConfigurationError(Exception):
     """An error that occurred during configuration."""
 
 
-class Configurer(Generic[Config, Key]):
+class Configurer(Generic[Key]):
     """Attempts to parse a pipeline into a space."""
 
     Error: ClassVar[type[ConfigurationError]] = ConfigurationError

--- a/src/byop/configuring/configurers/heirarchical_str.py
+++ b/src/byop/configuring/configurers/heirarchical_str.py
@@ -48,7 +48,7 @@ from byop.pipeline.pipeline import Pipeline
 from byop.types import Config, Name
 
 
-class HeirarchicalStrConfigurer(Configurer[Mapping[str, Any], str]):
+class HeirarchicalStrConfigurer(Configurer[str]):
     """A configurer that uses a mapping of strings to values."""
 
     @classmethod

--- a/src/byop/control/ask_and_tell.py
+++ b/src/byop/control/ask_and_tell.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Generic, ParamSpec, TypeVar
 
 from byop.optimization import Optimizer, Trial
 from byop.scheduling import Scheduler
-from byop.types import Config
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +20,7 @@ SuccessT = TypeVar("SuccessT")
 Info = TypeVar("Info")
 
 
-class AskAndTell(Generic[Info, Config]):
+class AskAndTell(Generic[Info]):
     """A controller that will run a target function and tell the optimizer
     the result.
     """

--- a/src/byop/optimization/optuna_opt.py
+++ b/src/byop/optimization/optuna_opt.py
@@ -75,9 +75,10 @@ class OptunaOptimizer(Optimizer[OptunaTrial]):
             The trial info for the new config.
         """
         optuna_trial = self.study.ask(self.space)
+        config = optuna_trial.params
         trial_number = optuna_trial.number
         unique_name = f"{trial_number=}"
-        return Trial(name=unique_name, info=optuna_trial)
+        return Trial(name=unique_name, config=config, info=optuna_trial)
 
     def tell(self, report: Trial.Report[OptunaTrial]) -> None:
         """Tell the optimizer the result of the sampled config.

--- a/src/byop/optimization/smac_opt.py
+++ b/src/byop/optimization/smac_opt.py
@@ -74,7 +74,7 @@ class SMACOptimizer(Optimizer[SMACTrialInfo]):
 
         config_id = self.facade.runhistory.config_ids[config]
         unique_name = f"{config_id=}.{instance=}.{seed=}.{budget=}"
-        return Trial(name=unique_name, info=smac_trial_info)
+        return Trial(name=unique_name, config=config, info=smac_trial_info)
 
     def tell(self, report: Trial.Report[SMACTrialInfo]) -> None:
         """Tell the optimizer the result of the sampled config.

--- a/src/byop/optimization/trial.py
+++ b/src/byop/optimization/trial.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from asyncio import Future
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Generic, Iterator, Literal, TypeVar
+from typing import Any, Callable, Generic, Iterator, Literal, Mapping, TypeVar
 
 from byop.events import Event, Subscriber
 from byop.exceptions import attach_traceback
@@ -28,6 +28,7 @@ class Trial(Generic[Info]):
         self,
         *,
         name: str,
+        config: Mapping[str, Any],
         info: Info,
         time: TimeInterval | None = None,
         timer: Timer | None = None,
@@ -37,12 +38,14 @@ class Trial(Generic[Info]):
 
         Args:
             name: The name of the trial.
+            config: The config for the trial.
             info: The info of the trial.
             time: The time taken by the trial.
             timer: The timer used to time the trial.
             exception: The exception raised by the trial, if any.
         """
         self.name = name
+        self.config = config
         self.info = info
         self.time = time
         self.timer = timer

--- a/src/byop/samplers/configspace.py
+++ b/src/byop/samplers/configspace.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ConfigSpace import Configuration, ConfigurationSpace
 
 
-class ConfigSpaceSampler(Sampler["ConfigurationSpace", "Configuration"]):
+class ConfigSpaceSampler(Sampler["ConfigurationSpace"]):
     """A sampler for a search space."""
 
     def __init__(

--- a/src/byop/samplers/sampler.py
+++ b/src/byop/samplers/sampler.py
@@ -12,7 +12,7 @@ from more_itertools import first_true
 from byop.types import Config, Seed, Space
 
 
-class Sampler(ABC, Generic[Space, Config]):
+class Sampler(ABC, Generic[Space]):
     """A sampler for a search space."""
 
     @abstractmethod
@@ -58,7 +58,7 @@ class Sampler(ABC, Generic[Space, Config]):
         return self.sample(n)
 
     @classmethod
-    def find(cls, space: Space) -> type[Sampler[Space, Config]]:
+    def find(cls, space: Space) -> type[Sampler[Space]]:
         """Find a sampler for the given space.
 
         Args:

--- a/src/byop/types.py
+++ b/src/byop/types.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Hashable, Iterator, Protocol, TypeVar, Union
+from typing import Any, Hashable, Iterator, Mapping, Protocol, TypeVar, Union
 
 import numpy as np
 from typing_extensions import TypeAlias
@@ -10,7 +10,7 @@ from typing_extensions import TypeAlias
 Item = TypeVar("Item")
 """The type associated with components, splits and choices"""
 
-Config = TypeVar("Config")
+Config: TypeAlias = Mapping[str, Any]
 """An object representing a configuration of a pipeline."""
 
 Space = TypeVar("Space")


### PR DESCRIPTION
In an effort to make things a bit more universal, we now always assume that a config from a space is a `Mapping[str, Any]`. This use of `Mapping` instead of `dict` still allows `ConfigurationSpace.Configuration` to work.

Addresses part of issue #21 