### PR TITLE
refactor(Pipeline): Remove Key and Name typevars, use `str`

### DIFF
--- a/src/byop/configuring/api.py
+++ b/src/byop/configuring/api.py
@@ -23,23 +23,21 @@ from byop.configuring.configurers import (
 )
 from byop.functional import reposition
 from byop.pipeline.pipeline import Pipeline
-from byop.types import Config, Key, Name, safe_isinstance
+from byop.types import Config, safe_isinstance
 
 if TYPE_CHECKING:
     import ConfigSpace
 
 
 def configure(
-    pipeline: Pipeline[Key, Name],
+    pipeline: Pipeline,
     config: Config | ConfigSpace.Configuration,
     *,
     configurer: (
-        Literal["auto"]
-        | Configurer
-        | Callable[[Pipeline[Key, Name], Config], Pipeline[Key, Name]]
+        Literal["auto"] | Configurer | Callable[[Pipeline, Config], Pipeline]
     ) = "auto",
-    rename: bool | Name = False,
-) -> Pipeline[Key, Name]:
+    rename: bool | str = False,
+) -> Pipeline:
     """Configure a pipeline with a given config.
 
     Args:
@@ -54,7 +52,7 @@ def configure(
     Returns:
         The configured pipeline.
     """
-    results: seekable[Result[Pipeline[Key, Name], ConfigurationError | Exception]]
+    results: seekable[Result[Pipeline, ConfigurationError | Exception]]
     configurers: list[Any]
 
     if configurer == "auto":

--- a/src/byop/configuring/configurers/configspace.py
+++ b/src/byop/configuring/configurers/configspace.py
@@ -9,23 +9,23 @@ from result import Result
 from byop.configuring.configurers.configurer import ConfigurationError, Configurer
 from byop.configuring.configurers.heirarchical_str import HeirarchicalStrConfigurer
 from byop.pipeline.pipeline import Pipeline
-from byop.types import Config, Name
+from byop.types import Config
 
 if TYPE_CHECKING:
     from ConfigSpace import Configuration
 
 
-class ConfigSpaceConfigurer(Configurer[str]):
+class ConfigSpaceConfigurer(Configurer):
     """A Configurer that uses a configure a pipeline."""
 
     @classmethod
     def _configure(
         cls,
-        pipeline: Pipeline[str, Name],
+        pipeline: Pipeline,
         config: Configuration,
         *,
         delimiter: str = ":",  # TODO: This could be a list of things to try
-    ) -> Result[Pipeline[str, Name], ConfigurationError | Exception]:
+    ) -> Result[Pipeline, ConfigurationError | Exception]:
         """Takes a pipeline and a config to produce a configured pipeline.
 
         Relies on there being a flat map structure in the config where the

--- a/src/byop/configuring/configurers/configurer.py
+++ b/src/byop/configuring/configurers/configurer.py
@@ -2,29 +2,25 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import ClassVar, Generic
+from typing import ClassVar
 
 from result import Result
 
 from byop.pipeline import Pipeline
-from byop.types import Config, Key, Name
+from byop.types import Config
 
 
 class ConfigurationError(Exception):
     """An error that occurred during configuration."""
 
 
-class Configurer(Generic[Key]):
+class Configurer:
     """Attempts to parse a pipeline into a space."""
 
     Error: ClassVar[type[ConfigurationError]] = ConfigurationError
 
     @classmethod
-    def configure(
-        cls,
-        pipeline: Pipeline[Key, Name],
-        config: Config,
-    ) -> Pipeline[Key, Name]:
+    def configure(cls, pipeline: Pipeline, config: Config) -> Pipeline:
         """Configure a pipeline with a given config.
 
         Args:
@@ -45,9 +41,9 @@ class Configurer(Generic[Key]):
     @abstractmethod
     def _configure(
         cls,
-        pipeline: Pipeline[Key, Name],
+        pipeline: Pipeline,
         config: Config,
-    ) -> Result[Pipeline[Key, Name], ConfigurationError | Exception]:
+    ) -> Result[Pipeline, ConfigurationError | Exception]:
         """Takes a pipeline and a config to produce a configured pipeline.
 
         Args:

--- a/src/byop/configuring/configurers/heirarchical_str.py
+++ b/src/byop/configuring/configurers/heirarchical_str.py
@@ -45,20 +45,20 @@ from result import Err, Ok, Result
 from byop.configuring.configurers.configurer import ConfigurationError, Configurer
 from byop.pipeline.components import Choice, Component, Split, Step
 from byop.pipeline.pipeline import Pipeline
-from byop.types import Config, Name
+from byop.types import Config
 
 
-class HeirarchicalStrConfigurer(Configurer[str]):
+class HeirarchicalStrConfigurer(Configurer):
     """A configurer that uses a mapping of strings to values."""
 
     @classmethod
     def _configure(
         cls,
-        pipeline: Pipeline[str, Name],
+        pipeline: Pipeline,
         config: Mapping[str, Any],
         *,
         delimiter: str = ":",  # TODO: This could be a list of things to try
-    ) -> Result[Pipeline[str, Name], ConfigurationError | Exception]:
+    ) -> Result[Pipeline, ConfigurationError | Exception]:
         """Takes a pipeline and a config to produce a configured pipeline.
 
         Relies on there being a flat map structure in the config where the
@@ -105,12 +105,12 @@ class HeirarchicalStrConfigurer(Configurer[str]):
 
 
 def _process(
-    step: Step[str],
+    step: Step,
     config: Mapping[str, Any],
     *,
     splits: list[Split] | None = None,
     delimiter: str = ":",
-) -> Iterator[Step[str]]:
+) -> Iterator[Step]:
     """Process a step, returning a new step with the config applied.
 
     Args:
@@ -129,7 +129,7 @@ def _process(
     def is_for_step(_key: str) -> bool:
         return _key.startswith(f"{step_key}{delimiter}")
 
-    def is_for_path(_key: str, _paths: Iterable[Step[str]]) -> bool:
+    def is_for_path(_key: str, _paths: Iterable[Step]) -> bool:
         return any(
             _key.startswith(f"{step_key}{delimiter}{_path.name}") for _path in _paths
         )

--- a/src/byop/pipeline/api.py
+++ b/src/byop/pipeline/api.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, Mapping, TypeVar, overload
 
 from byop.pipeline.components import Choice, Component, Split
-from byop.pipeline.step import Key, Step
+from byop.pipeline.step import Step
 
 Space = TypeVar("Space")
 T = TypeVar("T")
@@ -15,32 +15,32 @@ T = TypeVar("T")
 
 @overload
 def step(
-    name: Key,
+    name: str,
     item: T | Callable[..., T],
     *,
     config: Mapping[str, Any] | None = ...,
-) -> Component[Key, T, None]:
+) -> Component[T, None]:
     ...
 
 
 @overload
 def step(
-    name: Key,
+    name: str,
     item: T | Callable[..., T],
     *,
     space: Space,
     config: Mapping[str, Any] | None = ...,
-) -> Component[Key, T, Space]:
+) -> Component[T, Space]:
     ...
 
 
 def step(
-    name: Key,
+    name: str,
     item: T | Callable[..., T],
     *,
     space: Space | None = None,
     config: Mapping[str, Any] | None = None,
-) -> Component[Key, T, Space] | Component[Key, T, None]:
+) -> Component[T, Space] | Component[T, None]:
     """A step in a pipeline.
 
     Can be joined together with the `|` operator, creating a chain and returning
@@ -73,45 +73,45 @@ def step(
 
 @overload
 def choice(
-    name: Key,
+    name: str,
     *choices: Step,
     weights: Iterable[float] | None = ...,
     item: None = None,
-) -> Choice[Key, None, None]:
+) -> Choice[None, None]:
     ...
 
 
 @overload
 def choice(
-    name: Key,
+    name: str,
     *choices: Step,
     weights: Iterable[float] | None = ...,
     item: T,
     config: Mapping[str, Any] | None = ...,
-) -> Choice[Key, T, None]:
+) -> Choice[T, None]:
     ...
 
 
 @overload
 def choice(
-    name: Key,
+    name: str,
     *choices: Step,
     weights: Iterable[float] | None = ...,
     item: T,
     space: Space,
     config: Mapping[str, Any] | None = ...,
-) -> Choice[Key, T, Space]:
+) -> Choice[T, Space]:
     ...
 
 
 def choice(
-    name: Key,
+    name: str,
     *choices: Step,
     weights: Iterable[float] | None = None,
     item: T | None = None,
     space: Space | None = None,
     config: Mapping[str, Any] | None = None,
-) -> Choice[Key, T, Space] | Choice[Key, T, None] | Choice[Key, None, None]:
+) -> Choice[T, Space] | Choice[T, None] | Choice[None, None]:
     """Define a choice in a pipeline.
 
     Args:
@@ -143,40 +143,40 @@ def choice(
 
 @overload
 def split(
-    name: Key,
+    name: str,
     *paths: Step,
-) -> Split[Key, None, None]:
+) -> Split[None, None]:
     ...
 
 
 @overload
 def split(
-    name: Key,
+    name: str,
     *paths: Step,
     item: T | Callable[..., T],
     config: Mapping[str, Any] | None = ...,
-) -> Split[Key, T, None]:
+) -> Split[T, None]:
     ...
 
 
 @overload
 def split(
-    name: Key,
+    name: str,
     *paths: Step,
     item: T | Callable[..., T],
     space: Space,
     config: Mapping[str, Any] | None = ...,
-) -> Split[Key, T, Space]:
+) -> Split[T, Space]:
     ...
 
 
 def split(
-    name: Key,
+    name: str,
     *paths: Step,
     item: T | Callable[..., T] | None = None,
     space: Space | None = None,
     config: Mapping[str, Any] | None = None,
-) -> Split[Key, T, Space] | Split[Key, T, None] | Split[Key, None, None]:
+) -> Split[T, Space] | Split[T, None] | Split[None, None]:
     """Create a Split component, allowing data to flow multiple paths.
 
     Args:

--- a/src/byop/types.py
+++ b/src/byop/types.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Hashable, Iterator, Mapping, Protocol, TypeVar, Union
+from typing import Any, Iterator, Mapping, Protocol, TypeVar, Union
 
 import numpy as np
 from typing_extensions import TypeAlias
@@ -18,12 +18,6 @@ Space = TypeVar("Space")
 
 Seed: TypeAlias = Union[int, np.random.RandomState, np.random.Generator]
 """Type alias for kinds of Seeded objects"""
-
-Key = TypeVar("Key", bound=Hashable)
-"""The name of an individual step, requires being Hashable"""
-
-Name = TypeVar("Name", bound=Hashable)
-"""A name of a pipeline"""
 
 
 class Comparable(Protocol):

--- a/tests/pipeline/test_component.py
+++ b/tests/pipeline/test_component.py
@@ -80,6 +80,7 @@ def test_remove_many(head: Component) -> None:
     removals = chain.from_iterable(combinations(steps, length) for length in lens)
 
     for to_remove in removals:
-        removed_chain = list(head.remove(list(removals)))
-        expected = [s for s in head.iter() if s.name not in to_remove]
-        assert expected == removed_chain
+        names = [r.name for r in to_remove]
+        remaining = list(head.remove(names))
+        expected = [s for s in head.iter() if s.name not in names]
+        assert expected == remaining


### PR DESCRIPTION
This is to simplify the API quite a bit as well as reduce typing needs. Using Hashable could also work but in practice a `str` should suffice until proven otherwise.