### PR TITLE
fix(optuna): Accept `int` or `float` for reported values

### DIFF
--- a/src/byop/optuna/optimizer.py
+++ b/src/byop/optuna/optimizer.py
@@ -119,12 +119,14 @@ class OptunaOptimizer(Optimizer[OptunaTrial]):
             values = report.results["values"]
 
         if not (
-            isinstance(values, float)
+            isinstance(values, (float, int))
             or (
                 isinstance(values, Sequence)
-                and all(isinstance(value, float) for value in values)
+                and all(isinstance(value, (float, int)) for value in values)
             )
         ):
-            raise ValueError("Reported values should be float or a sequence of floats")
+            raise ValueError(
+                f"Reported {values=} should be float or a sequence of floats"
+            )
 
         return values


### PR DESCRIPTION
Whoops, didn't run a test properly before pushing #28. Optuna specifies it only accepts `float` in its `study.tell` but actually is supports anything that can be casted to `float` with `float(x)`. 