### PR TITLE
fix(deps): Add `pynisher` as required dependancy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "attrs",
   "pandas",
   "numpy",
-  "pynisher",
+  "pynisher>=1.0.5",
 ]
 requires-python = ">=3.8"
 authors = [{ name = "Eddie Bergman", email = "eddiebergmanhs@gmail.com" }]


### PR DESCRIPTION
Add `pynisher` as a required dependency. Technically this isn't required to function but `pynisher` is lightweight and managed by us. 