### PR TITLE
fix(Sampler): Better error message, `max_attempts=10` (default)

### DIFF
--- a/src/byop/building/_sklearn_builder.py
+++ b/src/byop/building/_sklearn_builder.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from byop.pipeline import Pipeline
     from sklearn.pipeline import Pipeline as SklearnPipeline
+
+    from byop.pipeline import Pipeline
 
 
 def sklearn_builder(pipeline: Pipeline) -> SklearnPipeline:

--- a/src/byop/exceptions.py
+++ b/src/byop/exceptions.py
@@ -82,7 +82,10 @@ def attach_traceback(exception: E) -> E:
     if err_type is KeyError:
         err_msg = _KeyErrorMessage(err_msg)
 
-    return err_type(err_msg)  # type: ignore
+    try:
+        return err_type(err_msg)  # type: ignore
+    except Exception:  # noqa: BLE001
+        return exception
 
 
 def safe_map(

--- a/src/byop/pipeline/pipeline.py
+++ b/src/byop/pipeline/pipeline.py
@@ -364,7 +364,7 @@ class Pipeline:
         sampler: type[Sampler[Space]] | Sampler[Space] | None = None,
         seed: Seed | None = None,
         duplicates: bool | Iterable[Config] = False,
-        max_attempts: int | None = 3,
+        max_attempts: int | None = 10,
     ) -> Config | list[Config]:
         """Sample a configuration from the space of the pipeline.
 

--- a/src/byop/pipeline/step.py
+++ b/src/byop/pipeline/step.py
@@ -316,9 +316,9 @@ class Step(Generic[Space]):
     @overload
     def space(
         self,
-        parser: Parser[Space],
+        parser: type[Parser[Space]] | Parser[Space],
         *,
-        seed: Seed | None = None,
+        seed: Seed | None = ...,
     ) -> Space:
         ...
 
@@ -327,13 +327,13 @@ class Step(Generic[Space]):
         self,
         parser: None = None,
         *,
-        seed: Seed | None = None,
+        seed: Seed | None = ...,
     ) -> Any:
         ...
 
     def space(
         self,
-        parser: Parser[Space] | None = None,
+        parser: type[Parser[Space]] | Parser[Space] | None = None,
         *,
         seed: Seed | None = None,
     ) -> Space | Any:
@@ -387,7 +387,7 @@ class Step(Generic[Space]):
         sampler: Sampler[Space] | None = None,
         seed: Seed | None = None,
         duplicates: bool | Iterable[Config] = False,
-        max_attempts: int | None = 3,
+        max_attempts: int | None = 10,
     ) -> Config | list[Config]:
         """Sample a configuration from the space of the pipeline.
 

--- a/src/byop/sklearn/builder.py
+++ b/src/byop/sklearn/builder.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, Union
 
-from byop.pipeline.components import Component, Split
-from byop.types import Any
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline as SklearnPipeline
+
+from byop.pipeline.components import Component, Split
+from byop.types import Any
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias

--- a/src/byop/sklearn/data.py
+++ b/src/byop/sklearn/data.py
@@ -5,9 +5,9 @@ from itertools import chain
 from typing import TYPE_CHECKING, Sequence
 
 from more_itertools import distribute, last
+from sklearn.model_selection import train_test_split
 
 from byop.randomness import as_int
-from sklearn.model_selection import train_test_split
 
 if TYPE_CHECKING:
     from byop.types import Seed

--- a/tests/building/test_sklearn.py
+++ b/tests/building/test_sklearn.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 from pytest_cases import parametrize
-
-from byop.configspace import ConfigSpaceParser
-from byop.pipeline import Pipeline, SpaceAdapter, choice, split, step
 from sklearn.compose import ColumnTransformer, make_column_selector
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.pipeline import Pipeline as SklearnPipeline
 from sklearn.preprocessing import OrdinalEncoder, StandardScaler
 from sklearn.svm import SVC
+
+from byop.configspace import ConfigSpaceParser
+from byop.pipeline import Pipeline, SpaceAdapter, choice, split, step
 
 # Some toy data
 X = pd.DataFrame({"a": ["1", "0", "1", "dog"], "b": [4, 5, 6, 7], "c": [7, 8, 9, 10]})

--- a/tests/configspace/test_sampling.py
+++ b/tests/configspace/test_sampling.py
@@ -202,8 +202,20 @@ def test_sample_with_seed_returns_same_results(
 ) -> None:
     space = item.space(parser=ConfigSpaceAdapter())
 
-    configs_1 = item.sample(space, sampler=ConfigSpaceAdapter(), seed=1, n=n)
-    configs_2 = item.sample(space, sampler=ConfigSpaceAdapter(), seed=1, n=n)
+    configs_1 = item.sample(
+        space,
+        sampler=ConfigSpaceAdapter(),
+        seed=1,
+        n=n,
+        duplicates=True,
+    )
+    configs_2 = item.sample(
+        space,
+        sampler=ConfigSpaceAdapter(),
+        seed=1,
+        n=n,
+        duplicates=True,
+    )
 
     assert configs_1 == configs_2
 

--- a/tests/optuna/test_sampling.py
+++ b/tests/optuna/test_sampling.py
@@ -105,8 +105,20 @@ def test_sample_with_seed_returns_same_results(
 ) -> None:
     space = item.space(parser=OptunaSpaceAdapter())
 
-    configs_1 = item.sample(space, sampler=OptunaSpaceAdapter(), seed=1, n=n)
-    configs_2 = item.sample(space, sampler=OptunaSpaceAdapter(), seed=1, n=n)
+    configs_1 = item.sample(
+        space,
+        sampler=OptunaSpaceAdapter(),
+        seed=1,
+        n=n,
+        duplicates=True,
+    )
+    configs_2 = item.sample(
+        space,
+        sampler=OptunaSpaceAdapter(),
+        seed=1,
+        n=n,
+        duplicates=True,
+    )
 
     assert configs_1 == configs_2
 


### PR DESCRIPTION
This PR does some slight changes to the sampling with no duplicates, doing full `n` samples instead of `n - len(already_sampled)` remaining and also bumps up the default to `max_attempts=10`.

This also improves the error message when it fails, informing users they may wish to bump this number themselves depending on the situation.