### PR TITLE
doc(CONTRIBUTING): fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,7 +328,7 @@ class Timer:
 
   def finish(self) -> None:
     self.end = time.time()
-    self.duration = self.start - self.end
+    self.duration = self.end - self.start
 
 timer = Timer()
 timer.start()


### PR DESCRIPTION
Fixing up some typos of the contribution guide.

I also have a remark about this part of the `Timer` example:

> ```python
> timer = Timer()
> timer.begin()
> print(timer.duration)  # This is None
> timer.end()  # User accidentally calls end instead of finish
> milliseconds_since_begining = time.end - time.start  # Whoops, no time interval
> ```

Calling `timer.end()` would actually already raise an error (because `None` is not callable).
Even if it were to work, in my opinion it is not a strong example for immutability: the example does not try to mutate the values, calling an attribute will raise an error also on immutable data. How about something like:

```python
from dataclasses import dataclass
import time

@dataclass
class Timer:
  start: float | None = None
  end: float | None = None

  @property
  def duration(self) -> float | None:
    return self.end - self.start if self.end else None

  def begin(self) -> None:
    self.start = time.time()

  def finish(self) -> None:
    self.end = time.time()

timer = Timer()
timer.begin()
timer.finish()
print(timer.duration)

timer.begin()
print(timer.duration)  # the duration is now negative!
```

Above example demonstrates that mutability can lead to inconsistent states that were not foreseen by the developer (even when not _directly_ meddling with public attributes by a user).