### PR TITLE
doc(BYOP): fix typos

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,6 +1,6 @@
-The guides here serve as a well structured introduction to the capabilities
-of AutoML-Toolkit. Notable we have three core concepts at the heart of
-AutoML-Toolkit, with supporting types and auxillary functionality to
+The guides here serve as a well-structured introduction to the capabilities
+of AutoML-Toolkit. Notably, we have three core concepts at the heart of
+AutoML-Toolkit, with supporting types and auxiliary functionality to
 enable these concepts.
 
 These take the form of a [`Task`][byop.scheduling.Task], a [`Pipeline`][byop.pipeline.Pipeline]
@@ -20,9 +20,9 @@ to create the most flexible optimization framework we could imagine.
     !!! tip "Notable Features"
 
         * A system that allows incremental and encapsulated feature addition.
-        * An event-driven system with an easy to use _callbacks_.
+        * An event-driven system with easy to use _callbacks_.
         * Place constraints on your `Task`.
-        * Integrations for different backends for where to run your tasks
+        * Integrations for different backends for where to run your tasks.
         * A wide set of events to plug into.
         * An easy to extend system to create your own specialized events and tasks.
 
@@ -36,7 +36,7 @@ to create the most flexible optimization framework we could imagine.
     defining what your **pipeline** will do and how
     it can be parametrized. By piecing together [`steps`][byop.pipeline.api.step],
     [`choices`][byop.pipeline.api.choice] and [`splits`][byop.pipeline.api.split], you can
-    say how you pipeline should look and how it's parametrized. We'll take care
+    say how your pipeline should look and how it's parametrized. We'll take care
     of creating the search space to optimize over, configuring it and finally assembling
     it into something you can actually use.
 

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -7,8 +7,8 @@ and extensible. This allows workflows which encourage gradual development
 and experimentation, where the user can incrementally add more functionality
 and complexity to their system.
 
-By the end of this guide, we hope that the following code, it's options
-and it's inner working becomes easy to understand.
+By the end of this guide, we hope that the following code, its options
+and its inner working become easy to understand.
 
 ```python
 from byop.scheduling import Scheduler, Task
@@ -36,17 +36,17 @@ scheduler.run()
 ```
 
 
-This guide starts with a simple introduce to `amltk`'s event system, which
-act as the gears through which the whole system moves.
+This guide starts with a simple introduction to `amltk`'s event system, which
+acts as the gears through which the whole system moves.
 After that, we introduce the engine, the [`Scheduler`][byop.scheduling.Scheduler]
-and how this interacts with python's built in interface [`Executor`][concurrent.futures.Executor]
+and how this interacts with python's built-in interface [`Executor`][concurrent.futures.Executor]
 to offload compute to processes, compute nodes or even cloud resources.
-However the `Scheduler` is rather useless without some fuel.
-For this we present [`Tasks`][byop.scheduling.Task], the compute to actually
+However, the `Scheduler` is rather useless without some fuel.
+For this, we present [`Tasks`][byop.scheduling.Task], the computational task to
 perform with the `Scheduler` and start the system's gears turning.
 
 ## Events
-At the core of of AutoML-Toolkit is an [`EventManager`][byop.events.EventManager]
+At the core of AutoML-Toolkit is an [`EventManager`][byop.events.EventManager]
 whose sole purpose is to allow you to do two things:
 
 * [`emit`][byop.events.EventManager.emit]: Emit some event with arguments.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ allowing you to define, search and build machine learning systems.
 
 -   :octicons-package-dependents-16: __Minimal Dependencies__
 
-    AutoML-Toolkit was designed to not introduce dependancies on your code.
+    AutoML-Toolkit was designed to not introduce dependencies on your code.
     We support some [integrations](./integrations) but only if they are optionally installed!.
 
 ---


### PR DESCRIPTION
Not sure when I have time to continue reading the documentation next, so I figured I would set up the PR already.

As an aside, the first code example `guides/task` _looks_ like it has some errors (see in-line comments).
I can guess how to resolve them, based on my first impression of the framework, but I'd want to wait until I actually read the docs and played around with `amltk`. Perhaps you want to address it in the meanwhile:

```python
from byop.scheduling import Scheduler, Task

def the_anwser(a: int, b: int, c: int) -> int:  #  "the_anwser" is likely a typo
    the_answer = ...    #  Fixing the function name means this variable would shadow the function
    return the_answer

scheduler = Scheduler(executor=...)
task = Task(compute_42, scheduler, ...)  # compute_42 is not defined

...

```