### PR TITLE
fix(pipeline): `request()` correctly sets config key

### DIFF
--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -727,8 +727,8 @@ class Node(RichRenderable, Generic[Item, Space]):
 
         for k, request in config.items():
             match request:
-                case ParamRequest(key=k) if k in _params:
-                    new_config[k] = _params[request.key]
+                case ParamRequest(key=request_key) if request_key in _params:
+                    new_config[k] = _params[request_key]
                 case ParamRequest(default=default) if request.has_default:
                     new_config[k] = default
                 case ParamRequest():

--- a/tests/pipeline/test_request.py
+++ b/tests/pipeline/test_request.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from amltk.exceptions import RequestNotMetError
+from amltk.pipeline import Component, request
+
+
+@dataclass
+class RandomModel:
+    """A model that makes random predictions."""
+
+    random_state: int | None = None
+
+
+def test_request_correctly_sets_config_on_object() -> None:
+    model = Component(RandomModel, config={"random_state": request("seed")})
+
+    expected_model = Component(RandomModel, config={"random_state": 42})
+    assert model.configure({}, params={"seed": 42}) == expected_model
+
+
+def test_request_with_default_sets_default() -> None:
+    model = Component(
+        RandomModel,
+        config={"random_state": request("seed", default=1337)},
+    )
+
+    expected_model = Component(RandomModel, config={"random_state": 1337})
+    assert model.configure({}) == expected_model
+
+
+def test_request_without_default_raises_when_not_provided() -> None:
+    model = Component(
+        RandomModel,
+        config={"random_state": request("seed")},
+    )
+
+    with pytest.raises(RequestNotMetError):
+        model.configure({})


### PR DESCRIPTION
Previously, the `case` statement was locally overriding the value `k` which caused param requests to be placed at the wrong key in the `node.config` when doing `configure(..., params={...})`

```python
for k, request in config.items():  # `k` defined here
	match request:
	    case ParamRequest(key=k) if k in _params:  # Whoops
	        new_config[k] = _params[request.key]
```

This was fixed and added some tests for the main behaviours of `request()`

@LennartPurucker I'll wait this time ;)