### PR TITLE
fix(dask-jobqueue): Prevent endless __enter__ cycle

### DIFF
--- a/docs/reference/scheduling/executors.md
+++ b/docs/reference/scheduling/executors.md
@@ -92,8 +92,9 @@ for scheduling jobs across common clusters setups such as
 PBS, Slurm, MOAB, SGE, LSF, and HTCondor.
 
 Please see the `dask-jobqueue` [documentation](https://jobqueue.dask.org/en/latest/)
-In particular, we only control the parameter `#!python n_workers=` to
-use the [`adapt()`](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+In particular, we only control the parameter `#!python n_workers=` and use `#!python adaptive=`
+to control where to use [`adapt()`](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+or [`scale()`](https://jobqueue.dask.org/en/latest/howitworks.html?highlight=scale()#scheduler-and-jobs)
 method, every other keyword is forwarded to the relative
 [cluster implementation](https://jobqueue.dask.org/en/latest/api.html).
 
@@ -113,6 +114,7 @@ to leave a PR or simply an issue!
 
         scheduler = Scheduler.with_slurm(
             n_workers=10,  # (1)!
+            adaptive=True,
             queue=...,
             cores=4,
             memory="6 GB",

--- a/src/amltk/scheduling/executors/dask_jobqueue.py
+++ b/src/amltk/scheduling/executors/dask_jobqueue.py
@@ -54,14 +54,12 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cluster: _JQC,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
     ):
         """Initialize a DaskJobqueueExecutor.
 
-        This will specifically use the
-        [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
-        method to dynamically scale the cluster to the number of workers specified.
 
         !!! note "Implementations"
 
@@ -79,18 +77,27 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             cluster: The implementation of a
                 [dask_jobqueue.JobQueueCluster](https://jobqueue.dask.org/en/latest/api.html).
             n_workers: The number of workers to maximally adapt to on the cluster.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed allocate all workers.
+                This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers specified.
             submit_command: To overwrite the submission command if necessary.
             cancel_command: To overwrite the cancel command if necessary.
         """
         super().__init__()
         self.cluster = cluster
+        self.adaptive = adaptive
         if submit_command:
             self.cluster.job_cls.submit_command = submit_command  # type: ignore
 
         if cancel_command:
             self.cluster.job_cls.cancel_command = cancel_command  # type: ignore
 
-        self.cluster.adapt(minimum=0, maximum=n_workers)
+        if adaptive:
+            self.cluster.adapt(minimum=0, maximum=n_workers)
+        else:
+            self.cluster.scale(n_workers)
+
         self.n_workers = n_workers
         self.executor: ClientExecutor = self.cluster.get_client().get_executor()
 
@@ -153,6 +160,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -167,6 +175,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             submit_command=submit_command,
             cancel_command=cancel_command,
             n_workers=n_workers,
+            adaptive=adaptive,
         )
 
     @classmethod
@@ -174,6 +183,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -187,6 +197,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             HTCondorCluster(**kwargs),
             submit_command=submit_command,
             cancel_command=cancel_command,
+            adaptive=adaptive,
             n_workers=n_workers,
         )
 
@@ -195,6 +206,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -208,6 +220,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             LSFCluster(**kwargs),
             submit_command=submit_command,
             cancel_command=cancel_command,
+            adaptive=adaptive,
             n_workers=n_workers,
         )
 
@@ -216,6 +229,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -229,6 +243,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             OARCluster(**kwargs),
             submit_command=submit_command,
             cancel_command=cancel_command,
+            adaptive=adaptive,
             n_workers=n_workers,
         )
 
@@ -237,6 +252,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -250,6 +266,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             PBSCluster(**kwargs),
             submit_command=submit_command,
             cancel_command=cancel_command,
+            adaptive=adaptive,
             n_workers=n_workers,
         )
 
@@ -258,6 +275,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -271,6 +289,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             SGECluster(**kwargs),
             submit_command=submit_command,
             cancel_command=cancel_command,
+            adaptive=adaptive,
             n_workers=n_workers,
         )
 
@@ -279,6 +298,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -292,6 +312,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             MoabCluster(**kwargs),
             submit_command=submit_command,
             cancel_command=cancel_command,
+            adaptive=adaptive,
             n_workers=n_workers,
         )
 
@@ -301,6 +322,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
         name: DJQ_NAMES,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -311,6 +333,10 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             name: The name of cluster to create, must be one of
                 ["slurm", "htcondor", "lsf", "oar", "pbs", "sge", "moab"].
             n_workers: The number of workers to maximally adapt to on the cluster.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed allocate all workers.
+                This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers specified.
             submit_command: Overwrite the submit command of workers if necessary.
             cancel_command: Overwrite the cancel command of workers if necessary.
             kwargs: The keyword arguments to pass to the cluster constructor.
@@ -340,5 +366,6 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
             n_workers=n_workers,
             submit_command=submit_command,
             cancel_command=cancel_command,
+            adaptive=adaptive,
             **kwargs,
         )

--- a/src/amltk/scheduling/executors/dask_jobqueue.py
+++ b/src/amltk/scheduling/executors/dask_jobqueue.py
@@ -96,7 +96,7 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
 
     @override
     def __enter__(self) -> Self:
-        with super().__enter__():
+        with self.executor:
             configuration = {
                 "header": self.cluster.job_header,
                 "script": self.cluster.job_script(),

--- a/src/amltk/scheduling/executors/dask_jobqueue.py
+++ b/src/amltk/scheduling/executors/dask_jobqueue.py
@@ -96,15 +96,19 @@ class DaskJobqueueExecutor(Executor, Generic[_JQC]):
 
     @override
     def __enter__(self) -> Self:
-        with self.executor:
-            configuration = {
-                "header": self.cluster.job_header,
-                "script": self.cluster.job_script(),
-                "job_name": self.cluster.job_name,
-            }
-            config_str = pprint.pformat(configuration)
-            logger.debug(f"Launching script with configuration:\n {config_str}")
-            return self
+        configuration = {
+            "header": self.cluster.job_header,
+            "script": self.cluster.job_script(),
+            "job_name": self.cluster.job_name,
+        }
+        config_str = pprint.pformat(configuration)
+        logger.debug(f"Launching script with configuration:\n {config_str}")
+        self.executor.__enter__()
+        return self
+
+    @override
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        self.executor.__exit__(*args, **kwargs)
 
     @override
     def submit(

--- a/src/amltk/scheduling/scheduler.py
+++ b/src/amltk/scheduling/scheduler.py
@@ -597,6 +597,7 @@ class Scheduler(RichRenderable):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -608,6 +609,11 @@ class Scheduler(RichRenderable):
 
         Args:
             n_workers: The number of workers to start.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
             kwargs: Any additional keyword arguments to pass to the
@@ -619,6 +625,7 @@ class Scheduler(RichRenderable):
         return cls.with_dask_jobqueue(
             "slurm",
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,
@@ -629,6 +636,7 @@ class Scheduler(RichRenderable):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -640,6 +648,11 @@ class Scheduler(RichRenderable):
 
         Args:
             n_workers: The number of workers to start.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
             kwargs: Any additional keyword arguments to pass to the
@@ -651,6 +664,7 @@ class Scheduler(RichRenderable):
         return cls.with_dask_jobqueue(
             "pbs",
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,
@@ -661,6 +675,7 @@ class Scheduler(RichRenderable):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -672,6 +687,11 @@ class Scheduler(RichRenderable):
 
         Args:
             n_workers: The number of workers to start.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
             kwargs: Any additional keyword arguments to pass to the
@@ -683,6 +703,7 @@ class Scheduler(RichRenderable):
         return cls.with_dask_jobqueue(
             "sge",
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,
@@ -693,6 +714,7 @@ class Scheduler(RichRenderable):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -704,6 +726,11 @@ class Scheduler(RichRenderable):
 
         Args:
             n_workers: The number of workers to start.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
             kwargs: Any additional keyword arguments to pass to the
@@ -715,6 +742,7 @@ class Scheduler(RichRenderable):
         return cls.with_dask_jobqueue(
             "oar",
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,
@@ -725,6 +753,7 @@ class Scheduler(RichRenderable):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -736,6 +765,11 @@ class Scheduler(RichRenderable):
 
         Args:
             n_workers: The number of workers to start.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
             kwargs: Any additional keyword arguments to pass to the
@@ -747,6 +781,7 @@ class Scheduler(RichRenderable):
         return cls.with_dask_jobqueue(
             "moab",
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,
@@ -757,6 +792,7 @@ class Scheduler(RichRenderable):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -768,6 +804,11 @@ class Scheduler(RichRenderable):
 
         Args:
             n_workers: The number of workers to start.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
             kwargs: Any additional keyword arguments to pass to the
@@ -779,6 +820,7 @@ class Scheduler(RichRenderable):
         return cls.with_dask_jobqueue(
             "lsf",
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,
@@ -789,6 +831,7 @@ class Scheduler(RichRenderable):
         cls,
         *,
         n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
         **kwargs: Any,
@@ -800,6 +843,11 @@ class Scheduler(RichRenderable):
 
         Args:
             n_workers: The number of workers to start.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
             kwargs: Any additional keyword arguments to pass to the
@@ -811,6 +859,7 @@ class Scheduler(RichRenderable):
         return cls.with_dask_jobqueue(
             "htcondor",
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,
@@ -821,9 +870,10 @@ class Scheduler(RichRenderable):
         cls,
         name: DJQ_NAMES,
         *,
+        n_workers: int,
+        adaptive: bool = False,
         submit_command: str | None = None,
         cancel_command: str | None = None,
-        n_workers: int,
         **kwargs: Any,
     ) -> Self:
         """Create a Scheduler with using `dask-jobqueue`.
@@ -836,6 +886,11 @@ class Scheduler(RichRenderable):
             name: The name of the jobqueue to use. This is the name of the
                 class in `dask_jobqueue` to use. For example, to use
                 `dask_jobqueue.SLURMCluster`, you would use `slurm`.
+            adaptive: Whether to use the adaptive scaling of the cluster or fixed
+                allocate all workers. This will specifically use the
+                [dask_jobqueue.SLURMCluster.adapt](https://jobqueue.dask.org/en/latest/index.html?highlight=adapt#adaptivity)
+                method to dynamically scale the cluster to the number of workers
+                specified.
             n_workers: The number of workers to start.
             submit_command: Overwrite the command to submit a worker if necessary.
             cancel_command: Overwrite the command to cancel a worker if necessary.
@@ -860,6 +915,7 @@ class Scheduler(RichRenderable):
         executor = DaskJobqueueExecutor.from_str(
             name,
             n_workers=n_workers,
+            adaptive=adaptive,
             submit_command=submit_command,
             cancel_command=cancel_command,
             **kwargs,

--- a/src/amltk/scheduling/scheduler.py
+++ b/src/amltk/scheduling/scheduler.py
@@ -269,7 +269,7 @@ from typing import (
     TypeVar,
     overload,
 )
-from typing_extensions import Self
+from typing_extensions import Self, override
 from uuid import uuid4
 
 from amltk._asyncm import ContextEvent
@@ -1412,9 +1412,11 @@ class Scheduler(RichRenderable):
         """
         self._renderables.append(renderable)
 
+    @override
     def __rich__(self) -> RenderableType:
         from rich.console import Group
         from rich.panel import Panel
+        from rich.pretty import Pretty
         from rich.table import Column, Table
         from rich.text import Text
         from rich.tree import Tree
@@ -1459,7 +1461,7 @@ class Scheduler(RichRenderable):
             expand=True,
             padding=(0, 1),
         )
-        layout_table.add_row(richify(self.executor), future_table)
+        layout_table.add_row(richify(self.executor, otherwise=Pretty), future_table)
 
         panel = Panel(
             layout_table,


### PR DESCRIPTION
Previously, `dask-jobqueue` based executors would default to `adapt()`. However this would lead to some unpredicted behaviour where not enough jobs were spawned and seemed to under-utilize resources with very few jobs. We changed the default to `scale()` but leave the option to set `adaptive=`.

There was a slight bug which caused an endless loop which should be fixed now.

