### PR TITLE
ci: Only test `"doc-runnable"` examples

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,9 +9,22 @@ HERE = Path(__file__).parent.resolve()
 EXAMPLE_DIR = HERE.parent / "examples"
 example_files = EXAMPLE_DIR.rglob("*.py")
 
+
+def is_runnable(example: Path) -> bool:
+    with example.open() as f:
+        # If `doc-runnable` is not in the first 10 lines,
+        # we don't consider it testable.
+        for _ in range(10):
+            line = next(f)
+            if "doc-runnable" in line.lower():
+                return True
+        return False
+
+
 parameters = [
     pytest.param(example, id=str(example.relative_to(EXAMPLE_DIR)))
     for example in example_files
+    if is_runnable(example)
 ]
 
 


### PR DESCRIPTION
The tests tried to run the dask-example and would just hang. This test is not meant to be run without a slurm cluster available. The fix is check example files have the `"doc-runnable"` flag (in the first 10 lines?) which is what the `docs/example_runner.py` does to check if it should run and render it.