### PR TITLE
fix: Provide more information if `built_item` fails

### DIFF
--- a/src/amltk/exceptions.py
+++ b/src/amltk/exceptions.py
@@ -88,7 +88,7 @@ class RequestNotMetError(ValueError):
     """Raised when a request is not met."""
 
 
-class ComponentBuildError(ValueError):
+class ComponentBuildError(TypeError):
     """Raised when failing to build a component."""
 
 

--- a/src/amltk/exceptions.py
+++ b/src/amltk/exceptions.py
@@ -88,6 +88,10 @@ class RequestNotMetError(ValueError):
     """Raised when a request is not met."""
 
 
+class ComponentBuildError(ValueError):
+    """Raised when failing to build a component."""
+
+
 class DuplicateNamesError(ValueError):
     """Raised when duplicate names are found."""
 

--- a/src/amltk/pipeline/components.py
+++ b/src/amltk/pipeline/components.py
@@ -877,7 +877,7 @@ class Component(Node[Item, Space]):
         config = self.config or {}
         try:
             return self.item(**{**config, **kwargs})
-        except ValueError as e:
+        except TypeError as e:
             new_msg = f"Failed to build {self.item} with {self.config}."
             if any(kwargs):
                 new_msg += f"Extra {kwargs=} were also provided."

--- a/src/amltk/pipeline/components.py
+++ b/src/amltk/pipeline/components.py
@@ -899,7 +899,7 @@ class Searchable(Node[None, Space]):  # type: ignore
     node of the pipeline which just represents a search space, no item attached.
 
     While not usually applicable to pipelines you want to build, this component
-    is useful for creating a search space, especially if the the real pipeline you
+    is useful for creating a search space, especially if the real pipeline you
     want to optimize can not be built directly. For example, if you are optimize
     a script, you may wish to use a `Searchable` to represent the search space
     of that script.

--- a/src/amltk/pipeline/components.py
+++ b/src/amltk/pipeline/components.py
@@ -878,17 +878,17 @@ class Component(Node[Item, Space]):
         try:
             return self.item(**{**config, **kwargs})
         except TypeError as e:
-            new_msg = f"Failed to build {self.item} with {self.config}."
+            new_msg = f"Failed to build `{self.item=}` with `{self.config=}`.\n"
             if any(kwargs):
-                new_msg += f"Extra {kwargs=} were also provided."
+                new_msg += f"Extra {kwargs=} were also provided.\n"
             new_msg += (
                 "If the item failed to initialize, a common reason can be forgetting"
                 " to call `configure()` on the `Component` or the pipeline it is in or"
                 " not calling `build()`/`build_item()` on the **returned** value of"
-                " `configure()`."
-                "\nReasons may also include not having fully specified the `config`"
+                " `configure()`.\n"
+                "Reasons may also include not having fully specified the `config`"
                 " initially, it having not being configured fully from `configure()`"
-                " or from misspecfying parameters."
+                " or from misspecfying parameters in the `space`."
             )
             raise ComponentBuildError(new_msg) from e
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to AMLTK! Please ensure you have taken a look at
the contribution guidelines: https://github.com/automl/AMLTK/blob/main/CONTRIBUTING.md

Please make sure that:

* you updated all docs, this includes the changelog (CHANGELOG.md)
* for any new functionality, consider adding a relevant example
* add unit tests for new functionalities
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #176


#### What does this implement/fix? Explain your changes.
Gives a better error message when calling `build()` or `build_item()` to provide
a more information to the user about what happened and how to fix it.

#### Minimal Example / How should this PR be tested?

<!--
This only needs to be filled if there is anything to test.
In case of a new feature, please add a minimal example of how to use it.
-->
```python
from dataclasses import dataclass
from amltk.pipeline import Component

@dataclass
class Model:
	f: float
	i: int

c = Component(Model, space={"f": (1.0, 2.0), "i": (1, 10)})

# User forgets to configure
# cc = c.configure(config={"f": 1, "i": 1})
c.build_item()  # Whoops, error raised

# User configures but then builds on original item
c.configure(config={"f": 1, "i": 1})  # Whoops, didnt act on return value
c.build_item()

# User does fully specify space
c = Component(Model, space={"f": (1.0, 2.0)})
cc = c.configure({"f": 1.0})
cc.build_item()
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.