### PR TITLE
fix(_doc): Catch missing else statement

### DIFF
--- a/src/amltk/_doc.py
+++ b/src/amltk/_doc.py
@@ -115,6 +115,7 @@ def doc_print(
     fontsize: str = "medium",
 ) -> None:
     if output == "svg":
+        # NOTE: This might fail if the things are not RichRenderable
         _print(as_rich_svg(*renderable, title=title, width=width))
     elif len(renderable) == 1:
         try:
@@ -123,7 +124,8 @@ def doc_print(
 
             if isinstance(renderable[0], Pipeline | BaseEstimator | TransformerMixin):
                 _print(renderable[0]._repr_html_())  # type: ignore
-                return
+            else:
+                _print(as_rich_html(renderable[0], width=width, fontsize=fontsize))  # type: ignore
         except Exception:  # noqa: BLE001
             _print(as_rich_html(*renderable, width=width, fontsize=fontsize))
     else:

--- a/src/amltk/pipeline/components.py
+++ b/src/amltk/pipeline/components.py
@@ -225,7 +225,7 @@ class Join(Node[Item, Space]):
         RandomForestClassifier(n_estimators=5),
         name="my_feature_union",
     )
-    print(join._repr_html_())  # markdown-exec: hide
+    from amltk._doc import doc_print; doc_print(print, join)  # markdown-exec: hide
     ```
 
     Like all [`Node`][amltk.pipeline.node.Node]s, a `Join` accepts an explicit


### PR DESCRIPTION
Previously, the `doc_print` command would do nothing if the renderable was not a pipeline, corrected now 