### PR TITLE
fix(data): `reduce_int_span` with nullable dtypes

### DIFF
--- a/src/amltk/data/dtype_reduction.py
+++ b/src/amltk/data/dtype_reduction.py
@@ -76,7 +76,15 @@ def reduce_int_span(x: D) -> D:
     min_dtype = np.min_scalar_type(x.min())  # type: ignore
     max_dtype = np.min_scalar_type(x.max())  # type: ignore
     dtype = np.result_type(min_dtype, max_dtype)
-    return x.astype(dtype)  # type: ignore
+
+    # The above dtype is a numpy dtype and may not allow for nullable values,
+    # which are permissible in pandas. `to_numeric` will convert to appropriate
+    # pandas nullable dtypes.
+    if isinstance(x, pd.Series):
+        dc = "unsigned" if "uint" in dtype.name else "integer"
+        return pd.to_numeric(x, downcast=dc)
+
+    return x.astype(dtype)
 
 
 def reduce_dtypes(x: D, *, reduce_int: bool = True, reduce_float: bool = True) -> D:

--- a/tests/data/test_dtype_reduction.py
+++ b/tests/data/test_dtype_reduction.py
@@ -7,6 +7,20 @@ from pytest_cases import parametrize
 from amltk.data.dtype_reduction import reduce_dtypes
 
 
+@parametrize(
+    "series, expected",
+    (
+        (pd.Series([1, 2, None], dtype=pd.Int64Dtype()), "UInt8"),
+        (pd.Series([1, 2342, None], dtype=pd.Int64Dtype()), "UInt16"),
+        (pd.Series([-1, 1, None], dtype=pd.Int64Dtype()), "Int8"),
+        (pd.Series([-1, 2342, None], dtype=pd.Int64Dtype()), "Int16"),
+    ),
+)
+def test_reduce_dtypes_with_pandas_nan_dtypes(series: pd.Series, expected: str) -> None:
+    reduced = reduce_dtypes(series)
+    assert reduced.dtype.name == expected
+
+
 def test_reduce_dtypes_mixed_df() -> None:
     # Default 8 bytes per number
     mixed_df = pd.DataFrame({"a": np.arange(100), "b": np.linspace(0, 1, 100)})

--- a/tests/data/test_dtype_reduction.py
+++ b/tests/data/test_dtype_reduction.py
@@ -26,7 +26,7 @@ def test_reduce_dtypes_mixed_df() -> None:
     mixed_df = pd.DataFrame({"a": np.arange(100), "b": np.linspace(0, 1, 100)})
     reduced_df = reduce_dtypes(mixed_df)
 
-    assert reduced_df["a"].dtype == np.uint8
+    assert reduced_df["a"].dtype == pd.UInt8Dtype()
     assert reduced_df["b"].dtype == pd.Float32Dtype()
 
 
@@ -34,14 +34,14 @@ def test_reduce_dtypes_mixed_df() -> None:
     "dtype, expected",
     [
         # For int's we squeeze to smallest possible that holds, max/min
-        (np.uint8, np.uint8),
-        (np.uint16, np.uint8),
-        (np.uint32, np.uint8),
-        (np.uint64, np.uint8),
-        (np.int8, np.uint8),
-        (np.int16, np.uint8),
-        (np.int32, np.uint8),
-        (np.int64, np.uint8),
+        (np.uint8, pd.UInt8Dtype()),
+        (np.uint16, pd.UInt8Dtype()),
+        (np.uint32, pd.UInt8Dtype()),
+        (np.uint64, pd.UInt8Dtype()),
+        (np.int8, pd.UInt8Dtype()),
+        (np.int16, pd.UInt8Dtype()),
+        (np.int32, pd.UInt8Dtype()),
+        (np.int64, pd.UInt8Dtype()),
         # For floats, we only do single step in precision reduction and
         # we default to pandas nullable float
         (np.float16, pd.Float32Dtype()),


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #134 

#### What does this implement/fix? Explain your changes.
Extra check during `reduce_int_span` now calls out to pandas when dealing with a `Series`. Previously, the `np.result_type` would return a `np.dtype` which has no support for nullables, which are allowed by pandas, through something like `"Int64"`

https://pandas.pydata.org/docs/user_guide/integer_na.html

#### Minimal Example / How should this PR be tested?
See tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.