### PR TITLE
fix(sklearn): Better default categorical dtypes

### DIFF
--- a/src/amltk/pipeline/builders/sklearn.py
+++ b/src/amltk/pipeline/builders/sklearn.py
@@ -223,12 +223,12 @@ def _process_split(
     config = dict(node.config) if node.config is not None else {}
 
     # Automatic categories/numerical config
-    for keyword, dtypes in (
-        ("categorical", [object, "category"]),
-        ("numerical", ["number"]),
+    for keyword, column_selector_kwargs in (
+        ("categorical", {"dtype_exclude": "number"}),
+        ("numerical", {"dtype_include": "number"}),
     ):
         if any(child.name == keyword for child in node.nodes) and keyword not in config:
-            config[keyword] = make_column_selector(dtype_include=dtypes)
+            config[keyword] = make_column_selector(**column_selector_kwargs)
 
     # Automatic numeric config
     if any(child.name not in config for child in node.nodes):


### PR DESCRIPTION
pandas doesn't have a catch all "category" kind of `dtype_include=` in [`select_dtypes`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.select_dtypes.html#pandas.DataFrame.select_dtypes) which is what `make_column_selector` uses. This mean explicitly listing Dtypes might miss out on a few, for example a `pd.StringDtype()` which would not have been included before.

To circumvent this limitation, we simply create a disjoint but partition of the set of all column kinds using `dtype_include=` and `dtype_exclude=`. 

Note, this only applies to defaults, a user may still pass in their own