### PR TITLE
fix(History): Explicitly check type in add()

### DIFF
--- a/src/amltk/optimization/history.py
+++ b/src/amltk/optimization/history.py
@@ -197,9 +197,21 @@ class History(RichRenderable):
 
                 self.reports.append(report)
                 self._lookup[report.name] = len(self.reports) - 1
-            case reports:
-                for _report in reports:
+            case Iterable():
+                for _report in report:
+                    # Could endless loop
+                    if not isinstance(_report, Trial.Report):
+                        raise TypeError(
+                            f"Expected an iterable of Trial.Report"
+                            f" but got {type(_report)} ({_report})"
+                            f" in add({report=})",
+                        )
                     self.add(_report)
+            case _:
+                raise TypeError(
+                    f"Expected a Trial.Report or an iterable of Trial.Report"
+                    f" but got {type(report)} ({report})",
+                )
 
     def find(self, name: str) -> Trial.Report:
         """Finds a report by trial name.


### PR DESCRIPTION
The issue is that previously this would error by recursion, instead of explicitly saying what went wrong. This error would be avoided by someone using a type-checker. Since this should accomodate notebook users who do not have these features readily available, we explicitly raise an error.

tldr; `str` is iterable so it kept looping on itself

```python
from amltk.optimization import History
history = History()

# Previously failed with a recursion error
history.add({"anything": 1})
```