### PR TITLE
feat(Scheduler): Respond to cancelled futures

### DIFF
--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -458,10 +458,12 @@ the `@on_future_exception` will be emitted, passing the exception to the callbac
 By default, the `Scheduler` will then raise the exception that occurred up to your program
 and end its computations. This is done by setting
 [`#!python run(on_exception="raise")`][amltk.scheduling.Scheduler],
-the default, but it also takes two other possibilities:
+the default, but it also takes three other possibilities:
 
-* `#!python "ignore"` - Just ignore the exception and keep running.
-* `#!python "end"` - Stop the scheduler but don't raise it.
+* `#!python "continue"` - Just emit the exception and keep running.
+* `#!python "end"` - Emit the exception and then stop the scheduler but don't raise it.
+* `#!python {MyException: "continue", OtherException: "raise"}` - Decide what to do
+    for each exception type. Note that this checked in order using `#!python isinstance(...)`
 
 One example is to just `stop()` the scheduler when some exception occurs.
 
@@ -483,7 +485,7 @@ def stop_the_scheduler(future: Future, exception: Exception) -> None:
     print(f"Got exception {exception}")
     scheduler.stop()  # You can optionally pass `exception=` for logging purposes.
 
-scheduler.run(on_exception="ignore")  # Scheduler will not stop because of the error
+scheduler.run(on_exception="continue")  # Scheduler will not stop because of the error
 from amltk._doc import doc_print; doc_print(print, scheduler, output="html", fontsize="small")  # markdown-exec: hide
 ```
 
@@ -494,7 +496,7 @@ By default when you call [`run()`][amltk.scheduling.Scheduler.run] it will set
 This is to help you debug your program.
 
 You may also use `#!python run(on_exception="end")`, which will just end the `Scheduler` and raise no exception,
-or use `#!python run(on_exception="ignore")`, in which case the `Scheduler` will continue on with whatever events
+or use `#!python run(on_exception="continue")`, in which case the `Scheduler` will continue on with whatever events
 are next to process.
 
 ## Tasks

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -296,14 +296,14 @@ def test_end_on_exception_in_task(scheduler: Scheduler) -> None:
     assert isinstance(end_status.exception, CustomError)
 
 
-def test_ignore_on_exception_in_task(scheduler: Scheduler) -> None:
+def test_continue_on_exception_in_task(scheduler: Scheduler) -> None:
     task = scheduler.task(raise_exception)
 
     @scheduler.on_start
     def run_task() -> None:
         task.submit()
 
-    end_status = scheduler.run(on_exception="ignore")
+    end_status = scheduler.run(on_exception="continue")
     assert end_status.code == ExitState.Code.EXHAUSTED
 
 
@@ -318,14 +318,14 @@ def test_mapping_on_exception_explicit_raise(scheduler: Scheduler) -> None:
         scheduler.run(on_exception={CustomError: "raise"})
 
 
-def test_mapping_on_exception_explicit_ignore(scheduler: Scheduler) -> None:
+def test_mapping_on_exception_explicit_continue(scheduler: Scheduler) -> None:
     task = scheduler.task(raise_exception)
 
     @scheduler.on_start
     def run_task() -> None:
         task.submit()
 
-    end_status = scheduler.run(on_exception={CustomError: "ignore"})
+    end_status = scheduler.run(on_exception={CustomError: "continue"})
     assert end_status.code == ExitState.Code.EXHAUSTED
 
 
@@ -380,7 +380,7 @@ def test_mapping_on_exception_defaults_to_raise_if_not_contained(
 
     # If we don't specify a mapping for an exception, it should default to raise.
     with pytest.raises(CustomError):
-        scheduler.run(on_exception={ValueError: "ignore"})
+        scheduler.run(on_exception={ValueError: "continue"})
 
 
 def test_mapping_on_exception_uses_ordering_raises(
@@ -394,10 +394,10 @@ def test_mapping_on_exception_uses_ordering_raises(
 
     # First one it matches should be CustomError
     with pytest.raises(CustomError):
-        scheduler.run(on_exception={CustomError: "raise", BaseCustomError: "ignore"})
+        scheduler.run(on_exception={CustomError: "raise", BaseCustomError: "continue"})
 
 
-def test_mapping_on_exception_uses_ordering_ignores(
+def test_mapping_on_exception_uses_ordering_continue(
     scheduler: Scheduler,
 ) -> None:
     task = scheduler.task(raise_exception)


### PR DESCRIPTION
This PR follows #213 conceptually, allowing users to `"raise"`, `"continue"` or `"end"` when a future was cancelled from the Scheduler.

The other major point is that the Literal argument `"ignore"` was renamed to `"continue"` to be more descriptive in terms of behaviour. The reason being is that `"ignore"` made it seem like the error would simply be ignored. This was not True as the `Scheduler` would still emit the exception, it was just continue after it.

Lastly, this PR does some cleanup to reduce the technical debt incurred by PR #213 