### PR TITLE
test: Update fixtures to be explicitly function scope

### DIFF
--- a/tests/scheduling/plugins/test_call_limiter_plugin.py
+++ b/tests/scheduling/plugins/test_call_limiter_plugin.py
@@ -51,7 +51,7 @@ def case_loky_executor() -> ProcessPoolExecutor:
     return get_reusable_executor(max_workers=2)  # type: ignore
 
 
-@fixture()
+@fixture(scope="function")
 @parametrize_with_cases("executor", cases=".", has_tag="executor")
 def scheduler(executor: Executor) -> Iterator[Scheduler]:
     yield Scheduler(executor)

--- a/tests/scheduling/plugins/test_comm_plugin.py
+++ b/tests/scheduling/plugins/test_comm_plugin.py
@@ -86,7 +86,7 @@ def case_dask_executor() -> ClientExecutor:
     return executor
 
 
-@fixture()
+@fixture(scope="function")
 @parametrize_with_cases("executor", cases=".", has_tag="executor")
 def scheduler(executor: Executor) -> Iterator[Scheduler]:
     yield Scheduler(executor)

--- a/tests/scheduling/plugins/test_pynisher_plugin.py
+++ b/tests/scheduling/plugins/test_pynisher_plugin.py
@@ -47,7 +47,7 @@ def case_dask_executor() -> ClientExecutor:
     return executor
 
 
-@fixture()
+@fixture(scope="function")
 @parametrize_with_cases("executor", cases=".", has_tag="executor")
 def scheduler(executor: Executor) -> Iterator[Scheduler]:
     yield Scheduler(executor)

--- a/tests/scheduling/plugins/test_threadpoolctl_plugin.py
+++ b/tests/scheduling/plugins/test_threadpoolctl_plugin.py
@@ -59,7 +59,7 @@ def case_loky_executor() -> ProcessPoolExecutor:
     return get_reusable_executor(max_workers=2)  # type: ignore
 
 
-@fixture()
+@fixture(scope="function")
 @parametrize_with_cases("executor", cases=".", has_tag="executor")
 def scheduler(executor: Executor) -> Scheduler:
     return Scheduler(executor)

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -80,7 +80,7 @@ def case_sequential_executor() -> SequentialExecutor:
     return SequentialExecutor()
 
 
-@fixture()
+@fixture(scope="function")
 @parametrize_with_cases("executor", cases=".", has_tag="executor")
 def scheduler(executor: Executor) -> Scheduler:
     return Scheduler(executor)

--- a/tests/store/test_bucket.py
+++ b/tests/store/test_bucket.py
@@ -36,7 +36,7 @@ def unjson_serialisable(x: Any) -> Any:
     return x
 
 
-@fixture
+@fixture(scope="function")
 @parametrize_with_cases("bucket", cases=".", prefix="bucket_")
 def bucket(bucket: Bucket) -> Bucket:
     return bucket


### PR DESCRIPTION
Noticed that they weren't specified, but good to be explicit that they should be function scope