### PR TITLE
feat(Pipeline): `factorize()` a pipeline into its possibilities

### DIFF
--- a/src/amltk/pipeline/__init__.py
+++ b/src/amltk/pipeline/__init__.py
@@ -11,6 +11,7 @@ from amltk.pipeline.components import (
     as_node,
 )
 from amltk.pipeline.node import Node, request
+from amltk.pipeline.ops import factorize
 
 __all__ = [
     "Node",
@@ -23,4 +24,5 @@ __all__ = [
     "Join",
     "request",
     "as_node",
+    "factorize",
 ]

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -160,7 +160,6 @@ class Node(RichRenderable, Generic[Item, Space]):
 
     fidelities: Mapping[str, Any] | None = field(hash=False)
     """The fidelities for this node"""
-
     config_transform: Callable[[Config, Any], Config] | None = field(hash=False)
     """A function that transforms the configuration of this node"""
 
@@ -633,6 +632,17 @@ class Node(RichRenderable, Generic[Item, Space]):
                 return _build(self, *builder_args, **builder_kwargs)  # type: ignore
             case _:
                 return builder(self, *builder_args, **builder_kwargs)
+
+    def factorize(
+        self,
+        *,
+        factor_by: Callable[[Node], bool] | None = None,
+        assign_child: Callable[[Node, Node], Node] | None = None,
+    ) -> Iterator[Self]:
+        """Please see [`factorize()`][amltk.pipeline.ops.factorize]."""  # noqa: D402
+        from amltk.pipeline.ops import factorize
+
+        yield from factorize(self, factor_by=factor_by, assign_child=assign_child)
 
     def _rich_iter(self) -> Iterator[RenderableType]:
         """Iterate the panels for rich printing."""

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -636,13 +636,23 @@ class Node(RichRenderable, Generic[Item, Space]):
     def factorize(
         self,
         *,
+        min_depth: int = 0,
+        max_depth: int | None = None,
+        current_depth: int = 0,
         factor_by: Callable[[Node], bool] | None = None,
         assign_child: Callable[[Node, Node], Node] | None = None,
     ) -> Iterator[Self]:
         """Please see [`factorize()`][amltk.pipeline.ops.factorize]."""  # noqa: D402
         from amltk.pipeline.ops import factorize
 
-        yield from factorize(self, factor_by=factor_by, assign_child=assign_child)
+        yield from factorize(
+            self,
+            min_depth=min_depth,
+            max_depth=max_depth,
+            current_depth=current_depth,
+            factor_by=factor_by,
+            assign_child=assign_child,
+        )
 
     def _rich_iter(self) -> Iterator[RenderableType]:
         """Iterate the panels for rich printing."""

--- a/src/amltk/pipeline/ops.py
+++ b/src/amltk/pipeline/ops.py
@@ -79,7 +79,8 @@ def factorize(
 
     # We can exit early as there's no chance we factorize past this point
     if current_depth > max_depth:
-        return node.copy()
+        yield node.copy()
+        return
 
     # NOTE: These two functions below are defined here instead to allow custom
     # Node types in the future. The default behaviour is defined to just split
@@ -104,7 +105,7 @@ def factorize(
         case Node(nodes=()):
             # Base case, there's no further possibility to factorize
             yield node.copy()
-        case Node(nodes=children) if factor_by(node) and current_depth >= min_depth:
+        case Node(nodes=children) if factor_by(node) and min_depth <= current_depth:
             for child in children:
                 for possible_child in _factorize(child):
                     split_node_with_child_assigned = assign_child(

--- a/src/amltk/pipeline/ops.py
+++ b/src/amltk/pipeline/ops.py
@@ -1,0 +1,93 @@
+"""Operations on pipelines."""
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from functools import partial
+from itertools import product
+from typing import TypeVar
+
+from amltk.pipeline.components import Choice
+from amltk.pipeline.node import Node
+
+NodeT1 = TypeVar("NodeT1", bound=Node)
+NodeT2 = TypeVar("NodeT2", bound=Node)
+
+
+def factorize(
+    node: NodeT1,
+    *,
+    factor_by: Callable[[Node], bool] | None = None,
+    assign_child: Callable[[NodeT2, Node], NodeT2] | None = None,
+) -> Iterator[NodeT1]:
+    """Factorize a pipeline into all possibilities of its children.
+
+    When dealing with a large pipeline with many choices at various levels,
+    it can be useful to factorize the pipeline into all possible pipelines.
+    This effectively returns a new pipeline for every possible choice in the
+    pipeline.
+
+    ```python exec="true" source="material-block" html="true"
+    from amltk.pipeline import Sequential, Choice, Node, factorize
+
+    pipeline = Sequential(
+        Choice(Node(name="hi"), Node(name="hello"), name="choice"),
+        Node(name="banana"),
+        name="pipeline",
+    )
+
+    from amltk._doc import doc_print; _print = print; print = lambda thing: doc_print(_print, thing)  # markdown-exec: hide
+    print(pipeline)
+    for i, possibility in enumerate(factorize(pipeline)):
+        print(f"Pipeline {i}:")
+        print(possibility)
+    ```
+
+    Args:
+        node: The node to factorize.
+        factor_by: A function that takes a node and returns True if it
+            should be factorized into its children, False otherwise. By
+            default, it will split only Choice nodes.
+        assign_child: A function that takes a node and a child and
+            returns a new node with that child assigned to it. By default,
+            it will mutate the node so that it has that child as its
+            only child. You may wish to pass in custom functionality if there
+            is more than one way to assign a child to a node or extra logic must
+            be done to the nodes properties.
+
+            It should return the same type of node as the one passed in.
+
+    Returns:
+        An iterator over all possible pipelines.
+    """  # noqa: E501
+    # NOTE: These two functions below are defined here instead to allow custom
+    # Node types in the future. The default behaviour is defined to just split
+    # Choice nodes and assign a child to one is to just mutate the node so
+    # that it has that child as its only child.
+    if factor_by is None:
+        factor_by = lambda _node: isinstance(_node, Choice)
+
+    if assign_child is None:
+        assign_child = lambda _node, _child: _node.mutate(nodes=(_child,))
+
+    _factorize = partial(factorize, factor_by=factor_by, assign_child=assign_child)
+
+    match node:
+        case Node(nodes=()):
+            # Base case, there's no further possibility to factorize
+            yield node.copy()
+        case Node(nodes=children) if factor_by(node):
+            for child in children:
+                for possible_child in _factorize(child):
+                    split_node_with_child_assigned = assign_child(node, possible_child)  # type: ignore
+                    yield split_node_with_child_assigned  # type: ignore
+
+        case Node(nodes=children):
+            # We need to return N copies of this node, with each
+            # enumerating over all the posibilities of its children
+            # e.g.
+            # | children_sets = ((1, 2), (3, 4), (5,))
+            # | for child_set in [(1, 3, 5,), (1, 4, 5,), (2, 3, 5,), (2, 4, 5,)]:
+            # |    yield node.mutate(nodes=child_set)
+            children_sets = (_factorize(c) for c in children)
+            for child_set in product(*children_sets):
+                yield node.mutate(nodes=child_set)

--- a/src/amltk/pipeline/ops.py
+++ b/src/amltk/pipeline/ops.py
@@ -78,7 +78,10 @@ def factorize(
         case Node(nodes=children) if factor_by(node):
             for child in children:
                 for possible_child in _factorize(child):
-                    split_node_with_child_assigned = assign_child(node, possible_child)  # type: ignore
+                    split_node_with_child_assigned = assign_child(
+                        node.copy(),  # type: ignore
+                        possible_child,
+                    )
                     yield split_node_with_child_assigned  # type: ignore
 
         case Node(nodes=children):

--- a/src/amltk/pipeline/ops.py
+++ b/src/amltk/pipeline/ops.py
@@ -19,7 +19,7 @@ def factorize(
     node: NodeT1,
     *,
     min_depth: int = 0,
-    max_depth: int = MAX_INT,
+    max_depth: int | None = None,
     current_depth: int = 0,
     factor_by: Callable[[Node], bool] | None = None,
     assign_child: Callable[[NodeT2, Node], NodeT2] | None = None,
@@ -56,7 +56,7 @@ def factorize(
         max_depth: The maximum depth at which to factorize. If the node is at a
             depth greater than this, it will not be factorized.
             Depth is calculated as the node distance from node which is passed in
-            plus the `current_depth`.
+            plus the `current_depth`. If `None`, there is no maximum depth.
         current_depth: The current depth of the node. This is used internally but
             can also be used externally to factorize a sub-pipeline.
         factor_by: A function that takes a node and returns True if it
@@ -83,6 +83,9 @@ def factorize(
     Returns:
         An iterator over all possible pipelines.
     """  # noqa: E501
+    if max_depth is None:
+        max_depth = MAX_INT
+
     if current_depth < 0:
         raise ValueError("current_depth cannot be less than 0")
 

--- a/src/amltk/pipeline/ops.py
+++ b/src/amltk/pipeline/ops.py
@@ -61,7 +61,16 @@ def factorize(
             can also be used externally to factorize a sub-pipeline.
         factor_by: A function that takes a node and returns True if it
             should be factorized into its children, False otherwise. By
-            default, it will split only Choice nodes.
+            default, it will split only Choice nodes. One useful example
+            is to only factor on a particular name of a node.
+
+            ```python
+            pipeline_per_estimator = list(factorize(
+                pipeline,
+                factor_by=lambda _node: _node.name == "estimator"
+            ))
+            ```
+
         assign_child: A function that takes a node and a child and
             returns a new node with that child assigned to it. By default,
             it will mutate the node so that it has that child as its

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -146,10 +146,12 @@ def test_find() -> None:
 
 
 def test_walk() -> None:
+    n1 = Node(name="1")
+
     sub3 = Node(name="sub3")
     sub2 = Node(sub3, name="sub2")
-    n1 = Node(name="1")
     n2 = Node(sub2, name="2")
+
     n3 = Node(name="3")
 
     seq = n1 >> n2 >> n3

--- a/tests/pipeline/test_ops.py
+++ b/tests/pipeline/test_ops.py
@@ -128,3 +128,81 @@ def test_double_nested_choice():
     ]
 
     assert list(factorize(pipeline)) == expected
+
+
+def test_factorize_with_min_depth_triggers_if_at_min_depth():
+    n1 = Node(name="n1")
+    n2 = Node(name="n2")
+
+    # Choice is at depth 1
+    seq = Sequential(Choice(n1, n2, name="c1"), name="s1")
+
+    expected = [
+        Sequential(Choice(n1, name="c1"), name="s1"),
+        Sequential(Choice(n2, name="c1"), name="s1"),
+    ]
+    assert list(factorize(seq, min_depth=1)) == expected
+
+
+def test_factorize_with_min_depth_greater_does_not_factor():
+    n1 = Node(name="n1")
+    n2 = Node(name="n2")
+
+    # Choice is at depth 0
+    choice = Choice(n1, n2, name="c1")
+
+    assert list(factorize(choice, min_depth=1_000)) == [choice]
+
+
+def test_factorize_with_max_depth_does_not_triggers_if_past_max_depth():
+    S = Sequential
+    n1 = Node(name="n1")
+    n2 = Node(name="n2")
+
+    # Choice is at depth 2
+    seq = S(S(Choice(n1, n2, name="c1"), name="s1"), name="s2")
+    assert list(factorize(seq, max_depth=1)) == [seq]
+
+
+def test_factorize_with_max_depth_triggers_if_not_at_max_depth():
+    n1 = Node(name="n1")
+    n2 = Node(name="n2")
+
+    # Choice is at depth 2
+    seq = Sequential(Choice(n1, n2, name="c1"), name="s1")
+
+    expected = [
+        Sequential(Choice(n1, name="c1"), name="s1"),
+        Sequential(Choice(n2, name="c1"), name="s1"),
+    ]
+    assert list(factorize(seq, max_depth=1_000)) == expected
+
+
+def test_with_custom_factor_by():
+    # We'll factorize by the name of the node
+    factor_by = lambda _node: _node.name == "estimator"
+
+    e1 = Node(name="e1")
+    e2 = Node(name="e2")
+    estimator = Choice(e1, e2, name="estimator")
+
+    p1 = Node(name="p1")
+    p2 = Node(name="p2")
+    preprocessor = Choice(p1, p2, name="preprocessor")
+
+    pipeline = Sequential(preprocessor, estimator, name="pipeline")
+
+    # Should only split out the estimator
+    expected = [
+        Sequential(
+            Choice(p1, p2, name="preprocessor"),
+            Choice(e1, name="estimator"),
+            name="pipeline",
+        ),
+        Sequential(
+            Choice(p1, p2, name="preprocessor"),
+            Choice(e2, name="estimator"),
+            name="pipeline",
+        ),
+    ]
+    assert list(factorize(pipeline, factor_by=factor_by)) == expected

--- a/tests/pipeline/test_ops.py
+++ b/tests/pipeline/test_ops.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from amltk.pipeline import Choice, Node
+from amltk.pipeline.components import Sequential
+from amltk.pipeline.ops import factorize
+
+
+def test_factorize_base_case():
+    node = Node(name="hi")
+    assert list(factorize(node)) == [node]
+
+
+def test_factorize_with_no_choices_returns_same_pipeline():
+    node = Node(Node(name="n1"), Node(name="n2"), name="n0")
+    assert list(factorize(node)) == [node]
+
+
+def test_factorize_with_single_choice_same_pipeline():
+    node = Choice(Node(name="n1"), name="c1")
+    assert list(factorize(node)) == [node]
+
+
+def test_factorize_with_two_choices_returns_both_pipelines():
+    n1 = Node(name="n1")
+    n2 = Node(name="n2")
+    choice = Choice(n1, n2, name="c1")
+    expected = [
+        Choice(n1, name="c1"),
+        Choice(n2, name="c1"),
+    ]
+    assert list(factorize(choice)) == expected
+
+
+def test_nested_choice_returns_possible_pipelines():
+    n1 = Node(name="n1")
+    n2 = Node(name="n2")
+    n3 = Node(name="n3")
+    choice = Choice(n1, n2, name="c1")
+    top = Sequential(choice, n3, name="s1")
+    expected = [
+        Sequential(Choice(n1, name="c1"), n3, name="s1"),
+        Sequential(Choice(n2, name="c1"), n3, name="s1"),
+    ]
+    assert list(factorize(top)) == expected
+
+
+def test_choice_followed_by_choice():
+    n1 = Node(name="n1")
+    n2 = Node(name="n2")
+    n3 = Node(name="n3")
+    pipeline = Sequential(
+        Choice(Choice(n1, n2, name="c2"), n3, name="c1"),
+        name="s1",
+    )
+    expected = [
+        Sequential(
+            Choice(
+                Choice(n1, name="c2"),
+                name="c1",
+            ),
+            name="s1",
+        ),
+        Sequential(
+            Choice(
+                Choice(n2, name="c2"),
+                name="c1",
+            ),
+            name="s1",
+        ),
+        Sequential(
+            Choice(n3, name="c1"),
+            name="s1",
+        ),
+    ]
+    assert list(factorize(pipeline)) == expected
+
+
+def test_double_nested_choice():
+    S = Sequential
+    C = Choice
+    N = Node
+    pipeline = S(
+        S(
+            C(N(name="n3.1.1"), N(name="n3.1.2"), name="c3.1"),
+            C(N(name="n3.2.1"), N(name="n3.2.2"), name="c3.2"),
+            name="s2.1",
+        ),
+        N(name="n2.2"),
+        name="s1",
+    )
+    expected = [
+        S(
+            S(
+                C(N(name="n3.1.1"), name="c3.1"),
+                C(N(name="n3.2.1"), name="c3.2"),
+                name="s2.1",
+            ),
+            N(name="n2.2"),
+            name="s1",
+        ),
+        S(
+            S(
+                C(N(name="n3.1.1"), name="c3.1"),
+                C(N(name="n3.2.2"), name="c3.2"),
+                name="s2.1",
+            ),
+            N(name="n2.2"),
+            name="s1",
+        ),
+        S(
+            S(
+                C(N(name="n3.1.2"), name="c3.1"),
+                C(N(name="n3.2.1"), name="c3.2"),
+                name="s2.1",
+            ),
+            N(name="n2.2"),
+            name="s1",
+        ),
+        S(
+            S(
+                C(N(name="n3.1.2"), name="c3.1"),
+                C(N(name="n3.2.2"), name="c3.2"),
+                name="s2.1",
+            ),
+            N(name="n2.2"),
+            name="s1",
+        ),
+    ]
+
+    assert list(factorize(pipeline)) == expected


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR implements a way to quickly factorize a pipeline with choices into individual pipelines where those choices are instead fixed (see image below for example).

The default behavior is to assume we want to create a new child for every child in a `Choice` and that to create this new pipeline, we just mutate the node and set that as it's only child.

```python
if isinstance(node, Choice):
    possible_choices = [node.mutate(nodes=(child,)) for child in node.children]
```

Edit:

By default this applies at all depths of the tree but you can also provide a `min_depth=` and `max_depth=` by which to regulate where splitting should occur. If you want to factor at a particular node you know in advance, please use `factor_by=` as a predicate as stated below. If you really need some more control, the recursive algorithm uses the `current_depth=` parameter.

---

There are also avenues for dependancy injection (as there are for things like builders and searchspace parsers).


Namely the algorithm works on two assumptions:
* There is a predicate `factor_by: Callable[[Node], bool]` to say if we should split which replaces the `isinstance` in the snippet above.
    * I.e. `estimator_node = lambda _node: _node.name == "estimator_choice"`
* We update a `Node` to only refer to a single child with `assign_child`, this replaces the `node.mutate(nodes=(child,))` in the snippet above.
    
```python
if factor_by(node):
    possible_choices = [assign_child(node.copy(), child) for child in children]
```

#### Minimal Example / How should this PR be tested?
![Screenshot_2024-01-18_13-05-42](https://github.com/automl/amltk/assets/15933394/fb86104e-007c-407b-a7ee-ac3ea19c9585)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.