### PR TITLE
feat(Pynisher): Detect tasks with `Trial` to report `FAIL`

### DIFF
--- a/src/amltk/scheduling/plugins/pynisher.py
+++ b/src/amltk/scheduling/plugins/pynisher.py
@@ -144,12 +144,6 @@ class _PynisherWrap(Generic[P, R]):
                         f"\n{trial=}",
                     )
                 trial = _trial
-            else:
-                raise ValueError(
-                    "Could not find a Trial instance in the args for PynisherPlugin."
-                    "\nPlease pass it as the first argument or as a keyword argument"
-                    " or disable trial handling with `disable_trial_handling=True`.",
-                )
 
         if trial is not None:
             try:

--- a/src/amltk/scheduling/plugins/pynisher.py
+++ b/src/amltk/scheduling/plugins/pynisher.py
@@ -82,14 +82,17 @@ performed in processes.
 """  # noqa: E501
 from __future__ import annotations
 
+import traceback
 from collections.abc import Callable
+from dataclasses import dataclass
 from multiprocessing.context import BaseContext
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeAlias, TypeVar
 from typing_extensions import ParamSpec, Self, override
 
 import pynisher
 import pynisher.exceptions
 
+from amltk.optimization import Trial
 from amltk.scheduling.events import Event
 from amltk.scheduling.plugins.plugin import Plugin
 
@@ -102,6 +105,62 @@ if TYPE_CHECKING:
 
 P = ParamSpec("P")
 R = TypeVar("R")
+
+
+@dataclass
+class _PynisherWrap(Generic[P, R]):
+    fn: Callable[P, R]
+    memory_limit: int | tuple[int, str] | None = None
+    cputime_limit: int | tuple[float, str] | None = None
+    walltime_limit: int | tuple[float, str] | None = None
+    terminate_child_processes: bool = True
+    context: BaseContext | None = None
+    disable_trial_handling: bool = False
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        if any(
+            limit is not None
+            for limit in (self.memory_limit, self.cputime_limit, self.walltime_limit)
+        ):
+            fn = pynisher.Pynisher(
+                self.fn,
+                memory=self.memory_limit,
+                cpu_time=self.cputime_limit,
+                wall_time=self.walltime_limit,
+                terminate_child_processes=True,
+                context=self.context,
+            )
+        else:
+            fn = self.fn
+
+        trial: Trial | None = None
+        if not self.disable_trial_handling:
+            if len(args) > 0 and isinstance(args[0], Trial):
+                trial = args[0]
+            elif (_trial := kwargs.get("trial")) is not None:
+                if not isinstance(_trial, Trial):
+                    raise ValueError(
+                        f"Expected 'trial' to be a Trial instance, got {type(trial)}"
+                        f"\n{trial=}",
+                    )
+                trial = _trial
+            else:
+                raise ValueError(
+                    "Could not find a Trial instance in the args for PynisherPlugin."
+                    "\nPlease pass it as the first argument or as a keyword argument"
+                    " or disable trial handling with `disable_trial_handling=True`.",
+                )
+
+        if trial is not None:
+            try:
+                return fn(*args, **kwargs)
+            except pynisher.PynisherException as e:
+                tb = traceback.format_exc()
+                trial.exception = e
+                trial.traceback = tb
+                return trial.fail()  # type: ignore
+        else:
+            return fn(*args, **kwargs)
 
 
 class PynisherPlugin(Plugin):
@@ -259,6 +318,7 @@ class PynisherPlugin(Plugin):
         cputime_limit: int | tuple[float, str] | None = None,
         walltime_limit: int | tuple[float, str] | None = None,
         context: BaseContext | None = None,
+        disable_trial_handling: bool = False,
     ):
         """Initialize a `PynisherPlugin` instance.
 
@@ -274,12 +334,61 @@ class PynisherPlugin(Plugin):
                 `("s", "m", "h")`. Defaults to `None`.
             context: The context to use for multiprocessing. Defaults to `None`.
                 See [`multiprocessing.get_context()`][multiprocessing.get_context]
+            disable_trial_handling: By default, the `PynisherPlugin` will auto-detect
+                if the task is one for a `Trial`. If so, it will catch any pynisher
+                specific exceptions and return a `Trial.Report` with `trial.fail()`,
+                instead of raising the expcetion. This has the effect that the report
+                can be caught with `task.on_result` where it can be handled. This will
+                also prevent the specific events `@pynisher-timeout`,
+                `@pynisher-memory-limit`, `@pynisher-cputime-limit`
+                and `@pynisher-walltime-limit` from being emitted.
+
+                If this
+                is `True`, then the pynisher exceptions will be raised as normal and
+                should be handled with `task.on_exception` where there is no direct
+                access to the `Trial` submitted.
+
+                ??? note "Auto-Detection"
+
+                    This will be triggered if the first positional argument is a
+                    `Trial` or if any of the keyword arguments are `"trial"`.
+
+                    ```python
+                    from amltk.optimization import Trial
+                    from amltk.scheduling import Scheduler
+
+                    def trial_evaluator_one(trial: Trial, ...) -> int:
+                        ...
+
+                    def trial_evaluator_two(..., trial: Trial) -> int:
+                        ...
+
+                    scheduler = Scheduler.with_processes(1)
+
+                    task_one = scheduler.task(
+                        trial_evaluator_one,
+                        plugins=PynisherPlugin(memory_limit=(1, "gb")
+                    )
+                    task_two = scheduler.task(
+                        trial_evaluator_two,
+                        plugins=PynisherPlugin(memory_limit=(1, "gb")
+                    )
+
+                    # Will auto-detect
+                    trial = Trial(...)
+                    task_one.submit(trial, ...)
+                    task_two.submit(..., trial=trial)
+
+                    # Will not auto-detect
+                    task_one.submit(42, trial)
+                    ```
         """
         super().__init__()
         self.memory_limit = memory_limit
         self.cputime_limit = cputime_limit
         self.walltime_limit = walltime_limit
         self.context = context
+        self.disable_trial_handling = disable_trial_handling
 
         self.task: Task
 
@@ -291,22 +400,16 @@ class PynisherPlugin(Plugin):
         **kwargs: P.kwargs,
     ) -> tuple[Callable[P, R], tuple, dict]:
         """Wrap a task function in a `Pynisher` instance."""
-        # If any of our limits is set, we need to wrap it in Pynisher
-        # to enfore these limits.
-        if any(
-            limit is not None
-            for limit in (self.memory_limit, self.cputime_limit, self.walltime_limit)
-        ):
-            fn = pynisher.Pynisher(
-                fn,
-                memory=self.memory_limit,
-                cpu_time=self.cputime_limit,
-                wall_time=self.walltime_limit,
-                terminate_child_processes=True,
-                context=self.context,
-            )
-
-        return fn, args, kwargs
+        _fn = _PynisherWrap(
+            fn,
+            disable_trial_handling=self.disable_trial_handling,
+            memory_limit=self.memory_limit,
+            cputime_limit=self.cputime_limit,
+            walltime_limit=self.walltime_limit,
+            context=self.context,
+            terminate_child_processes=True,
+        )
+        return _fn, args, kwargs
 
     @override
     def attach_task(self, task: Task) -> None:


### PR DESCRIPTION
If a task which was used for a `Trial`, such as those when optimizing trials from an Optimizer, exceeded it's constraints, it would previously just be a generic `Task` exception which would have to be handled with `@task.on_exception`. However it's often the case that we would rather get back a `Trial.fail()` through `@task.on_result` such that we can handle it in a uniform manner with other trials that failed. This also caused issues with the scheduler error handling mechanism for which #213 was introduced.

The new default behaviour of the `PynisherPlugin` is to auto-detect if a `Task` contains a `Trial`. If so and the `Task` exceeded one of it's constraints, it would simply return `task.fail()` with the relevant pynisher exception filled in. This behavior can be disabled with `disable_trial_handling`.

---

Take for example this function, we would like to report that the trial failed if it timed out during post-processing or caused a memory error during post processing, but we would also like to have a `ValueError` from human error still be classed as a `@task.on_exception`

```python
def fn(trial: Trial) -> Trial.Report:
	with trial.begin():
		# all good
		pass

	if trial.exception:
		return trial.fail()

	# !!! Memory exception or time exception raised here !!!
	# We likely want this to go under trial.fail()
	do_some_post_processing()

	# Value error from human error which we want to have
	# raised properly and not return a trial.fail() report
	1/0

	return trial.success()
	
reports = []
task = Task(fn, plugins=PynisherPlugin(...))


```

To handle errors as described above, you would do:

```python
@scheduler.on_start
def submit_trials():
    trial = get_next_trial()
    task.submit(trial)

@task.on_result
def handle_result(future, report: Trial.Report):
    match report.status:
    	case Trial.SUCCESS:
			print("trial success")
		case Trial.FAIL:
			print("trial failed")
	
    reports.add(report)
    
@task.on_exception
def handle_exception(_, exception: Exception):
	print("An unexpected exception occured!")
```

The previous work-around may have looked like this:

```python
reports = []
pending_trials: dict[Future, Trial] = {}

@scheduler.on_start
def submit_trials():
    trial = get_next_trial()
    future = task.submit(trial)
	self.pending_trials[future] = trial    

@task.on_result
def handle_result(future, report: Trial.Report):
	pending_trials.pop(report, None)
    match report.status:
    	case Trial.SUCCESS:
			print("trial success")
		case Trial.FAIL:
			print("trial failed")
	
    reports.add(report)
    
@task.on_exception
def handle_exception(future: Future, exception: Exception):
	trial = pending_trials.get(future)
   	if trial is not None and isinstance(trial.exception, PynisherPlugin.PynisherException):
			trial.exception = exception
	  		# How to access traceback here??
	       	fail_report = trial.fail()
			print("trial failed outside begin() block")
			return handle_result(future, fail_report)
	
	# Proceed with handling the syntax error handling you like
    print("An unexpected exception occured!")
```
