### PR TITLE
feat(Optimizer): Allow for batch ask requests

### DIFF
--- a/src/amltk/optimization/optimizer.py
+++ b/src/amltk/optimization/optimizer.py
@@ -16,9 +16,17 @@ extract the search space for the optimizer.
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Concatenate, Generic, ParamSpec, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Concatenate,
+    Generic,
+    ParamSpec,
+    TypeVar,
+    overload,
+)
 
 from more_itertools import all_unique
 
@@ -81,9 +89,22 @@ class Optimizer(Generic[I]):
             report: The report for a trial
         """
 
+    @overload
     @abstractmethod
-    def ask(self) -> Trial[I]:
+    def ask(self, n: int) -> Iterable[Trial[I]]:
+        ...
+
+    @overload
+    @abstractmethod
+    def ask(self, n: None = None) -> Trial[I]:
+        ...
+
+    @abstractmethod
+    def ask(self, n: int | None = None) -> Trial[I] | Iterable[Trial[I]]:
         """Ask the optimizer for a trial to evaluate.
+
+        Args:
+            n: The number of trials to ask for. If `None`, ask for a single trial.
 
         Returns:
             A config to sample.

--- a/src/amltk/optimization/optimizers/smac.py
+++ b/src/amltk/optimization/optimizers/smac.py
@@ -91,7 +91,7 @@ optimizer.bucket.rmdir()  # markdown-exec: hide
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -249,13 +249,31 @@ class SMACOptimizer(Optimizer[SMACTrialInfo]):
         )
         return cls(facade=facade, fidelities=fidelities, bucket=bucket, metrics=metrics)
 
+    @overload
+    def ask(self, n: int) -> Iterable[Trial[SMACTrialInfo]]:
+        ...
+
+    @overload
+    def ask(self, n: None = None) -> Trial[SMACTrialInfo]:
+        ...
+
     @override
-    def ask(self) -> Trial[SMACTrialInfo]:
+    def ask(
+        self,
+        n: int | None = None,
+    ) -> Trial[SMACTrialInfo] | Iterable[Trial[SMACTrialInfo]]:
         """Ask the optimizer for a new config.
+
+        Args:
+            n: The number of configs to ask for. If `None`, ask for a single config.
+
 
         Returns:
             The trial info for the new config.
         """
+        if n is not None:
+            return (self.ask(n=None) for _ in range(n))
+
         smac_trial_info = self.facade.ask()
         config = smac_trial_info.config
         budget = smac_trial_info.budget

--- a/tests/optimizers/test_optimizers.py
+++ b/tests/optimizers/test_optimizers.py
@@ -137,5 +137,6 @@ def test_batched_ask_generates_unique_configs(optimizer: Optimizer):
     # NOTE: This was tested with up to 100, at least from SMAC and Optuna.
     # It was quite slow for smac so I've reduced it to 10.
     # This is not a hard requirement of optimizers (maybe it should be?)
-    batch = optimizer.ask(10)
+    batch = list(optimizer.ask(10))
+    assert len(batch) == 10
     assert all_unique(batch)


### PR DESCRIPTION
This PR extends the `.ask()` of Optimizers to include an integer `ask(n: int | None = None)` where the default behaviour is to get a single configuration, while giving an `n` returns an iterator of configurations.

By default, optimizers which work in a sequential manner can simply call to them selves in a repeated fashion:

```python
if n is not None:
    return (self.ask(n=None) for _ range(n))
```

This PR is more aimed at supporting optimizers which support batched `ask`s. This can provide both theoretical improvements but also more optimized improvements. For example, if there is an evolutionary algorithm, computing `n` children can be faster than computing `1` child `n` times.

TODO:
* Currently every optimizer implemented just defaults to the sequential ask mechanism provided in the snippet above. We need to investigate if Optimizers support the batching mechanism and implement it if so. I've reached out to SMAC and NEPS. #225 
* Document it's usage #226 

---

This PR was done as a stepping stone towards another feature in progress I wanted to have this `n` positional parameter in a `PipelineOptimizer` be reserved, even though no optimizer has this batching implemented yet.