### PR TITLE
feat(Pipeline): `optimize()`

### DIFF
--- a/src/amltk/_richutil/__init__.py
+++ b/src/amltk/_richutil/__init__.py
@@ -1,6 +1,6 @@
 from amltk._richutil.renderable import RichRenderable
 from amltk._richutil.renderers import Function, rich_make_column_selector
-from amltk._richutil.util import df_to_table, richify
+from amltk._richutil.util import df_to_table, is_jupyter, richify
 
 __all__ = [
     "df_to_table",
@@ -8,4 +8,5 @@ __all__ = [
     "RichRenderable",
     "Function",
     "rich_make_column_selector",
+    "is_jupyter",
 ]

--- a/src/amltk/_richutil/util.py
+++ b/src/amltk/_richutil/util.py
@@ -3,6 +3,7 @@
 # where rich not being installed.
 from __future__ import annotations
 
+import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING, Any
 
@@ -70,3 +71,25 @@ def df_to_table(
         table.add_row(str(index), *[str(cell) for cell in row])
 
     return table
+
+
+def is_jupyter() -> bool:
+    """Return True if running in a Jupyter environment."""
+    # https://github.com/Textualize/rich/blob/fd981823644ccf50d685ac9c0cfe8e1e56c9dd35/rich/console.py#L518-L535
+    try:
+        get_ipython  # type: ignore[name-defined]  # noqa: B018
+    except NameError:
+        return False
+    ipython = get_ipython()  # type: ignore[name-defined]  # noqa: F821
+    shell = ipython.__class__.__name__
+    if (
+        "google.colab" in str(ipython.__class__)
+        or os.getenv("DATABRICKS_RUNTIME_VERSION")
+        or shell == "ZMQInteractiveShell"
+    ):
+        return True  # Jupyter notebook or qtconsole
+
+    if shell == "TerminalInteractiveShell":
+        return False  # Terminal running IPython
+
+    return False  # Other type (?)

--- a/src/amltk/_util.py
+++ b/src/amltk/_util.py
@@ -3,22 +3,41 @@ from __future__ import annotations
 from typing import Any
 
 
-def threadpoolctl_heuristic(thing: Any | None) -> bool:
+def threadpoolctl_heuristic(item_contained_in_node: Any | None) -> bool:
     """Heuristic to determine if we should automatically set threadpoolctl.
 
+    This is done by detecting if it's a scikit-learn `BaseEstimator` but this may
+    be extended in the future.
+
+    !!! tip
+
+        The reason to have this heuristic is that when running scikit-learn, or any
+        multithreaded model, in parallel, they will over subscribe to threads. This
+        causes a significant performance hit as most of the time is spent switching
+        thread contexts instead of work. This can be particularly bad for HPO where
+        we are evaluating multiple models in parallel on the same system.
+
+        The recommened thread count is 1 per core with no additional information to
+        act upon.
+
+    !!! todo
+
+        This is potentially not an issue if running on multiple nodes of some cluster,
+        as they do not share logical cores and hence do not clash.
+
     Args:
-        thing: The thing to check.
+        item_contained_in_node: The item with which to base the heuristic on.
 
     Returns:
         Whether we should automatically set threadpoolctl.
     """
-    if thing is None or not isinstance(thing, type):
+    if item_contained_in_node is None or not isinstance(item_contained_in_node, type):
         return False
 
     try:
         # NOTE: sklearn depends on threadpoolctl so it will be installed.
         from sklearn.base import BaseEstimator
 
-        return issubclass(thing, BaseEstimator)
+        return issubclass(item_contained_in_node, BaseEstimator)
     except ImportError:
         return False

--- a/src/amltk/_util.py
+++ b/src/amltk/_util.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def threadpoolctl_heuristic(thing: Any | None) -> bool:
+    """Heuristic to determine if we should automatically set threadpoolctl.
+
+    Args:
+        thing: The thing to check.
+
+    Returns:
+        Whether we should automatically set threadpoolctl.
+    """
+    if thing is None or not isinstance(thing, type):
+        return False
+
+    try:
+        # NOTE: sklearn depends on threadpoolctl so it will be installed.
+        from sklearn.base import BaseEstimator
+
+        return issubclass(thing, BaseEstimator)
+    except ImportError:
+        return False

--- a/src/amltk/evalutors/evaluation_protocol.py
+++ b/src/amltk/evalutors/evaluation_protocol.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class EvaluationProtocol:
-    """A protocol for how a trial and a pipeline should be evaluated."""
+    """A protocol for how a trial should be evaluated on a pipeline."""
 
     fn: Callable[[Trial, Node], Trial.Report]
 

--- a/src/amltk/evalutors/evaluation_protocol.py
+++ b/src/amltk/evalutors/evaluation_protocol.py
@@ -1,0 +1,59 @@
+"""Evaluation protocols for how a trial and a pipeline should be evaluated.
+
+TODO: Sorry
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
+
+from amltk.scheduling import Plugin
+
+if TYPE_CHECKING:
+    from amltk.optimization import Trial
+    from amltk.pipeline import Node
+    from amltk.scheduling import Scheduler, Task
+
+
+class EvaluationProtocol:
+    """A protocol for how a trial and a pipeline should be evaluated."""
+
+    fn: Callable[[Trial, Node], Trial.Report]
+
+    def task(
+        self,
+        scheduler: Scheduler,
+        plugins: Plugin | Iterable[Plugin] | None = None,
+    ) -> Task[[Trial, Node], Trial.Report]:
+        """Create a task for this protocol.
+
+        Args:
+            scheduler: The scheduler to use for the task.
+            plugins: The plugins to use for the task.
+
+        Returns:
+            The created task.
+        """
+        _plugins: tuple[Plugin, ...]
+        match plugins:
+            case None:
+                _plugins = ()
+            case Plugin():
+                _plugins = (plugins,)
+            case Iterable():
+                _plugins = tuple(plugins)
+
+        return scheduler.task(self.fn, plugins=_plugins)
+
+
+class CustomProtocol(EvaluationProtocol):
+    """A custom evaluation protocol based on a user function."""
+
+    def __init__(self, fn: Callable[[Trial, Node], Trial.Report]) -> None:
+        """Initialize the protocol.
+
+        Args:
+            fn: The function to use for the evaluation.
+        """
+        super().__init__()
+        self.fn = fn

--- a/src/amltk/optimization/history.py
+++ b/src/amltk/optimization/history.py
@@ -65,7 +65,7 @@ import operator
 from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable, Iterator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar, overload
 from typing_extensions import override
 
 import pandas as pd
@@ -527,7 +527,14 @@ class History(RichRenderable):
 
         return sorted(history.reports, key=sort_key, reverse=reverse)
 
-    @override
+    @overload
+    def __getitem__(self, key: int | str) -> Trial.Report:
+        ...
+
+    @overload
+    def __getitem__(self, key: slice) -> Trial.Report:
+        ...
+
     def __getitem__(  # type: ignore
         self,
         key: int | str | slice,

--- a/src/amltk/optimization/optimizer.py
+++ b/src/amltk/optimization/optimizer.py
@@ -146,8 +146,7 @@ class Optimizer(Generic[I]):
         !!! note
 
             Subclasses should override this with more specific configuration
-            but these 3 arguments should be all that's necessary to create
-            the optimizer.
+            but these arguments should be all that's necessary to create the optimizer.
 
         Args:
             space: The space to optimize over.

--- a/src/amltk/optimization/optimizer.py
+++ b/src/amltk/optimization/optimizer.py
@@ -15,18 +15,22 @@ extract the search space for the optimizer.
 """
 from __future__ import annotations
 
+import logging
 from abc import abstractmethod
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from datetime import datetime
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
     Concatenate,
     Generic,
     ParamSpec,
+    Protocol,
     TypeVar,
     overload,
 )
+from typing_extensions import Self
 
 from more_itertools import all_unique
 
@@ -36,10 +40,13 @@ if TYPE_CHECKING:
     from amltk.optimization.metric import Metric
     from amltk.optimization.trial import Trial
     from amltk.pipeline import Node
+    from amltk.types import Seed
 
 I = TypeVar("I")  # noqa: E741
 P = ParamSpec("P")
 ParserOutput = TypeVar("ParserOutput")
+
+logger = logging.getLogger(__name__)
 
 
 class Optimizer(Generic[I]):
@@ -123,3 +130,92 @@ class Optimizer(Generic[I]):
 
         """
         return None
+
+    @classmethod
+    @abstractmethod
+    def create(
+        cls,
+        *,
+        space: Node,
+        metrics: Metric | Sequence[Metric],
+        bucket: str | Path | PathBucket | None = None,
+        seed: Seed | None = None,
+    ) -> Self:
+        """Create this optimizer.
+
+        !!! note
+
+            Subclasses should override this with more specific configuration
+            but these 3 arguments should be all that's necessary to create
+            the optimizer.
+
+        Args:
+            space: The space to optimize over.
+            bucket: The bucket for where to store things related to the trial.
+            metrics: The metrics to optimize.
+            seed: The seed to use for the optimizer.
+
+        Returns:
+            The optimizer.
+        """
+
+    class CreateSignature(Protocol):
+        """A Protocol which defines the keywords required to create an
+        optimizer with deterministic behavior at a desired location.
+
+        This protocol matches the `Optimizer.create` classmethod, however we also
+        allow any function which accepts the keyword arguments to create an
+        Optimizer.
+        """
+
+        def __call__(
+            self,
+            *,
+            space: Node,
+            metrics: Metric | Sequence[Metric],
+            bucket: PathBucket | None = None,
+            seed: Seed | None = None,
+        ) -> Optimizer:
+            """A function which creates an optimizer for node.optimize should
+            accept the following keyword arguments.
+
+            Args:
+                space: The node to optimize
+                metrics: The metrics to optimize
+                bucket: The bucket to store the results in
+                seed: The seed to use for the optimization
+            """
+            ...
+
+    @classmethod
+    def _get_known_importable_optimizer_classes(cls) -> Iterator[type[Optimizer]]:
+        """Get all developer known optimizer classes. This is used for defaults.
+
+        Do not rely on this functionality and prefer to give concrete optimizers to
+        functionality requiring one. This is intended for convenience of particular
+        quickstart methods.
+        """
+        # NOTE: We can't use the `Optimizer.__subclasses__` method as the optimizers
+        # are not imported by any other module initially and so they do no exist
+        # until imported. Hence this manual iteration. For now, we be explicit and
+        # only if the optimizer list grows should we consider dynamic importing.
+        try:
+            from amltk.optimization.optimizers.smac import SMACOptimizer
+
+            yield SMACOptimizer
+        except ImportError as e:
+            logger.debug("Failed to import SMACOptimizer", exc_info=e)
+
+        try:
+            from amltk.optimization.optimizers.optuna import OptunaOptimizer
+
+            yield OptunaOptimizer
+        except ImportError as e:
+            logger.debug("Failed to import OptunaOptimizer", exc_info=e)
+
+        try:
+            from amltk.optimization.optimizers.neps import NEPSOptimizer
+
+            yield NEPSOptimizer
+        except ImportError as e:
+            logger.debug("Failed to import NEPSOptimizer", exc_info=e)

--- a/src/amltk/optimization/optimizers/neps.py
+++ b/src/amltk/optimization/optimizers/neps.py
@@ -249,7 +249,7 @@ class NEPSOptimizer(Optimizer[NEPSTrialInfo]):
         self,
         *,
         space: SearchSpace,
-        loss_metric: Metric,
+        loss_metric: Metric | Sequence[Metric],
         cost_metric: Metric | None = None,
         optimizer: BaseOptimizer,
         working_dir: Path,
@@ -307,7 +307,7 @@ class NEPSOptimizer(Optimizer[NEPSTrialInfo]):
             | Mapping[str, ConfigurationSpace | Parameter]
             | Node
         ),
-        metrics: Metric,
+        metrics: Metric | Sequence[Metric],
         cost_metric: Metric | None = None,
         bucket: PathBucket | str | Path | None = None,
         searcher: str | BaseOptimizer = "default",

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -989,12 +989,12 @@ class Node(RichRenderable, Generic[Item, Space]):
                 then it will be used to evaluate the pipeline.
 
                 * If `target` is a function, then it must take in a
-                [`Trial`][amltk.pipeline.trial.Trial] as the first argument
+                [`Trial`][amltk.optimization.trial.Trial] as the first argument
                 and a [`Node`][amltk.pipeline.node.Node] second argument, returning a
-                [`Trial.Report`][amltk.pipeline.trial.Trial.Report]. Please refer to
+                [`Trial.Report`][amltk.optimization.trial.Trial.Report]. Please refer to
                 the [optimization guide](../../../guides/optimization.md) for more.
 
-                * If `target` is a [`Task`][amltk.pipeline.task.Task], then
+                * If `target` is a [`Task`][amltk.scheduling.task.Task], then
                 this is not implemeneted yet. Sorry
             metric:
                 The metric(s) that will be passed to `optimizer=`. These metrics
@@ -1004,7 +1004,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                 of known optimizers and use the first one it can find which was installed.
 
                 Alternatively, this can be a class inheriting from
-                [`Optimizer`][amltk.optimizers.Optimizer] or else
+                [`Optimizer`][amltk.optimization.optimizer.Optimizer] or else
                 a signature match [`Optimizer.CreateSignature`][amltk.optimization.Optimizer.CreateSignature]
 
                 ??? tip "`Optimizer.CreateSignature`"
@@ -1047,7 +1047,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                 Any items you store in trials will be located in this directory,
                 where the [`trial.name`][amltk.optimization.Trial.name] will be
                 used as a subfolder where any contents stored with
-                [`trial.store()`][amlkt.optimization.Trial.store] will be put there.
+                [`trial.store()`][amltk.optimization.trial.Trial.store] will be put there.
                 Please see the [optimization guide](../../../guides/optimization.md)
                 for more on trial storage.
             scheduler:
@@ -1055,7 +1055,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                 If `None`, then one will be created for you with
                 [`Scheduler.with_processes(n_workers)`][amltk.scheduling.Scheduler.with_processes]
             history:
-                A [`History`][amltk.scheduling.History] to store the
+                A [`History`][amltk.optimization.history.History] to store the
                 [`Trial.Report`][amltk.optimization.Trial.Report]s in. You
                 may pass in your own if you wish for this method to store
                 it there instead of creating its own.
@@ -1089,31 +1089,34 @@ class Node(RichRenderable, Generic[Item, Space]):
                 optimization will continue for as long as the scheduler is
                 running. You'll likely want to configure this.
             process_memory_limit:
-                If specified, the [`Task`][amltk.pipeline.task.Task] will
+                If specified, the [`Task`][amltk.scheduling.task.Task] will
                 use the
                 [`PynisherPlugin`][amltk.scheduling.plugins.pynisher.PynisherPlugin]
                 to limit the memory the process can use. Please
-                refer to the [`pynisher`][amltk.schedule.plugins.pynisher]
+                refer to the
+                [plugins `pynisher` reference](../../../reference/scheduling/plugins.md#pynisher)
                 for more as there are platform limitations and additional
                 dependancies required.
             process_walltime_limit:
-                If specified, the [`Task`][amltk.pipeline.task.Task] will
+                If specified, the [`Task`][amltk.scheduling.task.Task] will
                 use the
                 [`PynisherPlugin`][amltk.scheduling.plugins.pynisher.PynisherPlugin]
                 to limit the wall time the process can use. Please
-                refer to the [`pynisher`][amltk.schedule.plugins.pynisher]
+                refer to the
+                [plugins `pynisher` reference](../../../reference/scheduling/plugins.md#pynisher)
                 for more as there are platform limitations and additional
                 dependancies required.
             process_cputime_limit:
-                If specified, the [`Task`][amltk.pipeline.task.Task] will
+                If specified, the [`Task`][amltk.scheduling.task.Task] will
                 use the
                 [`PynisherPlugin`][amltk.scheduling.plugins.pynisher.PynisherPlugin]
                 to limit the cputime the process can use. Please
-                refer to the [`pynisher`][amltk.schedule.plugins.pynisher]
+                refer to the
+                [plugins `pynisher` reference](../../../reference/scheduling/plugins.md#pynisher)
                 for more as there are platform limitations and additional
                 dependancies required.
             threadpool_limit_ctl:
-                If specified, the [`Task`][amltk.pipeline.task.Task] will
+                If specified, the [`Task`][amltk.scheduling.task.Task] will
                 use the
                 [`ThreadPoolCTLPlugin`][amltk.scheduling.plugins.threadpoolctl.ThreadPoolCTLPlugin]
                 to limit the number of threads used by compliant libraries.
@@ -1126,7 +1129,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                 Please set this to `True`/`False` depending on your preference.
             plugins:
                 Additional plugins to attach to the eventual
-                [`Task`][amltk.pipeline.task.Task] that will be executed by
+                [`Task`][amltk.scheduling.task.Task] that will be executed by
                 the [`Scheduler`][amltk.scheduling.Scheduler]. Please
                 refer to the
                 [plugins reference](../../../reference/scheduling/plugins.md) for more.

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -1222,7 +1222,7 @@ class Node(RichRenderable, Generic[Item, Space]):
             seed=seed,
         )
 
-        task = target.task(scheduler=scheduler, plugins=plugins)
+        task = target.task(scheduler=scheduler, plugins=_plugins)
 
         if on_begin is not None:
             hook = partial(on_begin, task, scheduler, history)
@@ -1295,7 +1295,7 @@ class Node(RichRenderable, Generic[Item, Space]):
         process_cputime_limit: int | tuple[float, str] | None = None,
         threadpool_limit_ctl: bool | int | None = None,
         # `scheduler.run()` arguments
-        display: bool = True,
+        display: bool | Literal["auto"] = "auto",
         wait: bool = True,
         on_scheduler_exception: Literal["raise", "end", "continue"] = "raise",
     ) -> History:
@@ -1346,8 +1346,12 @@ class Node(RichRenderable, Generic[Item, Space]):
                 effect if `setup_only=False` which is the default. Otherwise,
                 it will be ignored.
             display:
-                Whether to display the scheduler during running. This may
-                work poorly if including print statements or logging.
+                Whether to display the scheduler during running. By default
+                it is `"auto"` which means to enable the display if running
+                in a juptyer notebook or colab. Otherwise, it will be
+                `False`.
+
+                This may work poorly if including print statements or logging.
             wait:
                 Whether to wait for the scheduler to finish all pending jobs
                 if was stopped for any reason, e.g. a `timeout=` or

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -1123,7 +1123,7 @@ class Node(RichRenderable, Generic[Item, Space]):
         if threadpool_limit_ctl is not False:
             from amltk.scheduling.plugins.threadpoolctl import ThreadPoolCTLPlugin
 
-            plugins = (*_plugins, ThreadPoolCTLPlugin(threadpool_limit_ctl))
+            _plugins = (*_plugins, ThreadPoolCTLPlugin(threadpool_limit_ctl))
 
         match max_trials:
             case None:

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -1083,7 +1083,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                 walltime_limit=process_walltime_limit,
                 cputime_limit=process_cputime_limit,
             )
-            plugins = (*_plugins, plugin)
+            _plugins = (*_plugins, plugin)
 
         # If threadpool_limit_ctl None, we should default to inspecting if it's
         # an sklearn pipeline. This is because sklearn pipelines

--- a/src/amltk/scheduling/scheduler.py
+++ b/src/amltk/scheduling/scheduler.py
@@ -1302,7 +1302,7 @@ class Scheduler(RichRenderable):
         ) = "raise",
         on_cancelled: Literal["raise", "end", "continue"] = "raise",
         asyncio_debug_mode: bool = False,
-        display: bool | Iterable[RenderableType] = False,
+        display: bool | Iterable[RenderableType] | Literal["auto"] = "auto",
     ) -> ExitState:
         """Run the scheduler.
 
@@ -1378,6 +1378,11 @@ class Scheduler(RichRenderable):
                 Defaults to `False`. Please see [asyncio.run][] for more.
             display: Whether to display the scheduler live in the console.
 
+                * If `#!python "auto"`, will display the scheduler if in
+                    a notebook or colab environemnt. Otherwise, it will not display
+                    it. If left as "auto" and the display occurs, a warning will
+                    be printed alongside it.
+                * If `#!python False`, will not display anything.
                 * If `#!python True`, will display the scheduler and all its tasks.
                 * If a `#!python list[RenderableType]` , will display the scheduler
                     itself plus those renderables.
@@ -1388,6 +1393,20 @@ class Scheduler(RichRenderable):
         Raises:
             RuntimeError: If the scheduler is already running.
         """
+        if display == "auto":
+            from amltk._richutil import is_jupyter
+
+            display = is_jupyter()
+            if display is True:
+                warnings.warn(
+                    "Detected that current running context is in a notebook!"
+                    " When `display='auto'`, the default, the scheduler will"
+                    " automatically be set to display. If you do not want this or"
+                    " wish to disable this warning, please set `display=False`.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
         return asyncio.run(
             self.async_run(
                 timeout=timeout,

--- a/src/amltk/scheduling/task.py
+++ b/src/amltk/scheduling/task.py
@@ -444,7 +444,7 @@ class Task(RichRenderable, Generic[P, R]):
 
     @override
     def __repr__(self) -> str:
-        kwargs = {"unique_ref": self.unique_ref}
+        kwargs = {"unique_ref": self.unique_ref, "plugins": self.plugins}
         kwargs_str = ", ".join(f"{k}={v}" for k, v in kwargs.items())
         return f"{self.__class__.__name__}({kwargs_str})"
 

--- a/src/amltk/store/paths/path_bucket.py
+++ b/src/amltk/store/paths/path_bucket.py
@@ -108,7 +108,7 @@ class PathBucket(Bucket[str, Path]):
 
     def __init__(
         self,
-        path: Path | str,
+        path: PathBucket | Path | str,
         *,
         loaders: Sequence[type[PathLoader]] | None = None,
         create: bool = True,
@@ -135,6 +135,8 @@ class PathBucket(Bucket[str, Path]):
 
         if isinstance(path, str):
             path = Path(path)
+        elif isinstance(path, PathBucket):
+            path = path.path
 
         if clean and path.exists():
             shutil.rmtree(path, ignore_errors=True)
@@ -146,7 +148,7 @@ class PathBucket(Bucket[str, Path]):
             path.mkdir(parents=True, exist_ok=True)
 
         self._create = create
-        self.path = path
+        self.path: Path = path
         self.loaders = _loaders
 
     def sizes(self) -> dict[str, int]:

--- a/src/amltk/types.py
+++ b/src/amltk/types.py
@@ -31,7 +31,7 @@ Config: TypeAlias = Mapping[str, Any]
 Space = TypeVar("Space")
 """Generic for objects that are aware of a space but not the specific kind"""
 
-Seed: TypeAlias = int | np.integer | (np.random.RandomState | np.random.Generator)
+Seed: TypeAlias = int | np.integer | np.random.RandomState | np.random.Generator
 """Type alias for kinds of Seeded objects."""
 
 FidT: TypeAlias = tuple[int, int] | tuple[float, float] | list[Any]

--- a/tests/pipeline/test_optimize.py
+++ b/tests/pipeline/test_optimize.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+import threadpoolctl
+
+from amltk import Component, Metric, Node, Trial
+from amltk.optimization.history import History
+from amltk.optimization.optimizers.smac import SMACOptimizer
+from amltk.scheduling.scheduler import Scheduler
+from amltk.scheduling.task import Task
+from amltk.store import PathBucket
+from amltk.types import Seed
+
+METRIC = Metric("acc", minimize=False, bounds=(0.0, 1.0))
+
+
+class _CustomError(Exception):
+    pass
+
+
+def target_funtion(trial: Trial, pipeline: Node) -> Trial.Report:  # noqa: ARG001
+    # We don't really care here
+    with trial.begin():
+        pass
+
+    threadpool_info = threadpoolctl.threadpool_info()
+    trial.summary["num_threads"] = threadpool_info[0]["num_threads"]
+    return trial.success(acc=0.5)
+
+
+def test_custom_callback_used(tmp_path: Path) -> None:
+    def my_callback(task: Task, scheduler: Scheduler, history: History) -> None:  # noqa: ARG001
+        raise _CustomError()
+
+    component = Component(object, space={"a": (0.0, 1.0)})
+
+    with pytest.raises(_CustomError):
+        component.optimize(
+            target_funtion,
+            metric=METRIC,
+            on_begin=my_callback,
+            max_trials=1,
+            working_dir=tmp_path,
+        )
+
+
+def test_populates_given_history(tmp_path: Path) -> None:
+    history = History()
+    component = Component(object, space={"a": (0.0, 1.0)})
+    trial = Trial(name="test_trial", config={})
+    with trial.begin():
+        pass
+    report = trial.success()
+    history.add(report)
+
+    component.optimize(
+        target_funtion,
+        metric=METRIC,
+        history=history,
+        max_trials=1,
+        working_dir=tmp_path,
+    )
+
+
+def test_custom_create_optimizer_signature(tmp_path: Path) -> None:
+    component = Component(object, space={"a": (0.0, 1.0)})
+
+    def my_custom_optimizer_creator(
+        *,
+        space: Node,
+        metrics: Metric | Sequence[Metric],
+        bucket: PathBucket | None = None,
+        seed: Seed | None = None,
+    ) -> SMACOptimizer:
+        assert space is component
+        assert metrics is METRIC
+        assert bucket is not None
+        assert bucket.path == tmp_path
+        assert seed == 1
+
+        raise _CustomError()
+
+    with pytest.raises(_CustomError):
+        component.optimize(
+            target_funtion,
+            metric=METRIC,
+            optimizer=my_custom_optimizer_creator,
+            max_trials=1,
+            seed=1,
+            working_dir=tmp_path,
+        )
+
+
+def test_history_populated_with_exactly_maximum_trials(tmp_path: Path) -> None:
+    component = Component(object, space={"a": (0.0, 1.0)})
+    history = component.optimize(
+        target_funtion,
+        metric=METRIC,
+        max_trials=10,
+        working_dir=tmp_path,
+    )
+    assert len(history) == 10
+
+
+def test_sklearn_head_triggers_triggers_threadpoolctl(tmp_path: Path) -> None:
+    from sklearn.ensemble import RandomForestClassifier
+
+    info = threadpoolctl.threadpool_info()
+    num_threads = info[0]["num_threads"]
+
+    component = Component(RandomForestClassifier, space={"a": (0.0, 1.0)})
+    history = component.optimize(
+        target_funtion,
+        metric=METRIC,
+        max_trials=1,
+        working_dir=tmp_path,
+    )
+
+    report = history[0]
+    # Should have a different number of threads in there. By default 1
+    assert report.summary["num_threads"] != num_threads
+    assert report.summary["num_threads"] == 1
+
+
+def test_no_sklearn_head_does_not_trigger_threadpoolctl(tmp_path: Path) -> None:
+    info = threadpoolctl.threadpool_info()
+    num_threads = info[0]["num_threads"]
+
+    component = Component(object, space={"a": (0.0, 1.0)})
+    history = component.optimize(
+        target_funtion,
+        metric=METRIC,
+        max_trials=1,
+        working_dir=tmp_path,
+    )
+
+    report = history[0]
+    assert report.summary["num_threads"] == num_threads


### PR DESCRIPTION
TODO:
* Cleaning up documentation errors
* Creating a issue to re-write some of the optimization guide which should draw heavy attention to this feature.

Alright, buckle up, this is a bigger one (780 lines added).

The objective of this PR was to enable `pipeline.optimize(...)` to support fastest defaults towards just, well evaluating a pipeline, while still enabling it to extend out further into the future and not be too locked up in terms of use case.

### Get me HPO results quickly
Let's start with the simplest procedure:

```python
pipline = ...
history = pipeline.optimize(...)  # <- What needs to go in here
```

The first thing is the `.optimizer(target=...)` which should be a function that given a `Trial` and `Node` (pipeline), should return a `Trial.Report`, formally: `Callable[[Trial, Node], Trial.Report]`. This is the users target function to use HPO nomeclature.

The `target=` can also be an `EvaluationProtocol`, which will be used to define pre-defined flows so to speak. For example, a future addition would allow something like:

```python
pipeline.optimize(
    target=SklearnCVProtocol(X, y, splitter=...),  # User can use predefined evaluation protocols
    ...
)
```

### Choosing an Optimizer and Creating one
The next parts revolve around the optimizer, namely `optimizer=` to select one, the `seed=`, `working_dir=` and `metrics=` it will expect. These constitue the changes to the `Optimizer` class. By default, it's `None` and just tries to get some optimizer installed and use that. There could be extra work to also detect what's compatible with the pipeline, but if they're using a custom seearch space defintion, then they likely will be able to pass in the specific optimizer they wanted anywho.

### Scheduling
Next things to consider were about task execution, namely around the `Scheduler` and running it. It just uses `n_workers: int = 1` and `scheduler: Scheduler | None = None` to mean that it runs the opimization in local processes with `1` worker. Both of these parameters can be freely changed though. There are also a host of parameters related to error control, plugins and `max_trials=` and more which are documented in the code and understandable through there.

### Finer Control
The last major part to understand is `setup_only: bool = False`. We assume the default behaviour is as the code snippet above, "just get me some HPO runs". However more advanced users (me) might want to have multiple pipelines setup to run HPO, but I do not want to start them yet, and only care more about setting up the entire flow.

```python
pipeline = ...
scheduler = pipeline.optimizer(..., setup_only=True)
```

In this case, the pipeline is ready to be optimized and will run as soon as I call `scheduler.run()` where notably, I am now in control of the scheduler and the `run()` call.

---

Other use cases considered:
* You want to use your own `History` object which may be shared between pipeline optimization runs. `optimize(history=my_history)`. This won't lock or cause race conflicts as all callbacks happen async in the main process.
* You may want custom callbacks, this is handled through `on_begin` which allows you to do a host of custom things which have been documented.

