### PR TITLE
refactor(trial): Deprecate default behaviour of `begin()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ def evaluate(trial: Trial) -> Trial.Report:
         trial.store({"model.pkl": model, "predictions.npy": predictions}),
         return trial.success(accuracy=0.8, inference_time=...)
 
-    if trial.exception:
-        return trial.fail()
-
 # Easily swap between optimizers, without needing to change the rest of your code
 from amltk.optimization.optimizers.smac import SMACOptimizer
 from amltk.optimization.optimizers.smac import OptunaOptimizer

--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -129,18 +129,16 @@ for _ in range(10):
     x = trial.config["my-searchable:x"]
 
     # Begin the trial
-    with trial.begin(catch_warnings=True):
-        score = poly(x)
-
-    if trial.exception is None:
-        # Generate a success report
-        report: Trial.Report = trial.success(score=score)
-    else:
-        # Generate a failed report (i.e. poly(x) raised divide by zero exception with x=0)
-        report: Trial.Report = trial.fail()
+    with trial.begin():
+        try:
+            score = poly(x)
+        except Exception as e:
+            report = trial.fail(exception=e)
+        else:
+            report = trial.success(score=score)
 
     # Store artifacts with the trial, using file extensions to infer how to store it
-    trial.store({ "config.json": trial.config, "array.npy": [1, 2, 3] })
+    trial.store({"config.json": trial.config, "array.npy": [1, 2, 3] })
 
     # Tell the Optimizer about the report
     optimizer.tell(report)

--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -132,8 +132,8 @@ for _ in range(10):
     with trial.begin():
         try:
             score = poly(x)
-        except Exception as e:
-            report = trial.fail(exception=e)
+        except Exception as exception:
+            report = trial.fail(exception)
         else:
             report = trial.success(score=score)
 

--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -129,7 +129,7 @@ for _ in range(10):
     x = trial.config["my-searchable:x"]
 
     # Begin the trial
-    with trial.begin():
+    with trial.begin(catch_warnings=True):
         score = poly(x)
 
     if trial.exception is None:

--- a/examples/dask-jobqueue.py
+++ b/examples/dask-jobqueue.py
@@ -102,11 +102,10 @@ def target_function(trial: Trial, _pipeline: Node) -> Trial.Report:
     sklearn_pipeline = _pipeline.configure(trial.config).build("sklearn")
 
     with trial.begin():
-        sklearn_pipeline.fit(X_train, y_train)
-
-    if trial.exception:
-        trial.store({"exception.txt": f"{trial.exception}\n {trial.traceback}"})
-        return trial.fail()
+        try:
+            sklearn_pipeline.fit(X_train, y_train)
+        except Exception as e:
+            return trial.fail(exception=e)
 
     with trial.profile("predictions"):
         train_predictions = sklearn_pipeline.predict(X_train)

--- a/examples/dask-jobqueue.py
+++ b/examples/dask-jobqueue.py
@@ -105,7 +105,7 @@ def target_function(trial: Trial, _pipeline: Node) -> Trial.Report:
         try:
             sklearn_pipeline.fit(X_train, y_train)
         except Exception as e:
-            return trial.fail(exception=e)
+            return trial.fail(e)
 
     with trial.profile("predictions"):
         train_predictions = sklearn_pipeline.predict(X_train)

--- a/examples/hpo.py
+++ b/examples/hpo.py
@@ -120,16 +120,14 @@ def target_function(trial: Trial, _pipeline: Node) -> Trial.Report:
     # Configure the pipeline with the trial config before building it.
     sklearn_pipeline = _pipeline.configure(trial.config).build("sklearn")
 
-    # Fit the pipeline, indicating when you want to start the trial timing and error
-    # catchnig.
-    with trial.begin():
-        sklearn_pipeline.fit(X_train, y_train)
-
-    # If an exception happened, we use `trial.fail` to indicate that the
-    # trial failed
-    if trial.exception:
-        trial.store({"exception.txt": f"{trial.exception}\n {trial.traceback}"})
-        return trial.fail()
+    # Fit the pipeline, indicating when you want to start the trial timing
+    try:
+        with trial.begin():
+            sklearn_pipeline.fit(X_train, y_train)
+    except Exception as e:
+        # If something went wrong, we can just return a failed report
+        # with the exception
+        return trial.fail(exception=e)
 
     # Make our predictions with the model
     with trial.profile("predictions"):

--- a/examples/hpo.py
+++ b/examples/hpo.py
@@ -127,7 +127,7 @@ def target_function(trial: Trial, _pipeline: Node) -> Trial.Report:
     except Exception as e:
         # If something went wrong, we can just return a failed report
         # with the exception
-        return trial.fail(exception=e)
+        return trial.fail(e)
 
     # Make our predictions with the model
     with trial.profile("predictions"):

--- a/examples/hpo_with_ensembling.py
+++ b/examples/hpo_with_ensembling.py
@@ -214,7 +214,7 @@ def target_function(
     pipeline = pipeline.configure(trial.config)  # <!> (2)!
     sklearn_pipeline = pipeline.build("sklearn")  # <!>
 
-    with trial.begin():  # <!> (3)!
+    with trial.begin(catch_exceptions=True):  # <!> (3)!
         sklearn_pipeline.fit(X_train, y_train)
 
     if trial.exception:

--- a/src/amltk/optimization/history.py
+++ b/src/amltk/optimization/history.py
@@ -19,9 +19,6 @@ used to keep a structured record of what occured with
         with trial.begin():
             loss = x**2 - y
 
-        if trial.exception:
-            return trial.fail()
-
         return trial.success(loss=loss)
 
     # ... usually obtained from an optimizer

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -305,7 +305,7 @@ class Trial(RichRenderable, Generic[I]):
 
             The behaviour previosuly was to always swallow errors and not
             raise them. This is now deprecated and will be changed to raising
-            the error by default in the future. To keep the old behaviour,
+            the error by default (`False`) in the future. To keep the old behaviour,
             please explicitly set `catch_exceptions=True`.
 
         ```python exec="true" source="material-block" result="python" title="begin" hl_lines="5"
@@ -340,12 +340,12 @@ class Trial(RichRenderable, Generic[I]):
                 During the `with` block, if an exception is raised, this will
                 attached to the trial. You can specify what to do then.
 
-                * `"raise"`: Will raise the exception after attaching it to the trial.
-                * `"catch"`: Will catch the exception and attach it to the trial, without
+                * `False`: Will raise the exception after attaching it to the trial.
+                * `True`: Will catch the exception and attach it to the trial, without
                     raising it.
-                * `None`: A deprecated value which for now implies `"catch"`.
-                    This will change `"raise"` in the future and should be explicitly
-                    set to `"catch"` if you want to catch the exception.
+                * `None`: A deprecated value which for now implies `True`.
+                    This will change `False` in the future and should be explicitly
+                    set to `True` if you want to catch the exception.
 
 
             time: The timer kind to use for the trial. Defaults to the default

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -497,7 +497,7 @@ class Trial(RichRenderable, Generic[I]):
             try:
                 raise ValueError("This is an error")  # Something went wrong
             except Exception as e:
-                report = trial.fail(exception=e)
+                report = trial.fail(e)
             else:
                 report = trial.success(loss=1)
 


### PR DESCRIPTION
Currently `trial.begin()` will silently eat errors and relies on an explicit idiom of checking the exception after the block. While this is convenient, it's silent behavior and it's better to have users explicitly enable it.

New behavior to be enabled at some point is to just raise it by default. Users can either deal with it on their own, e.g. with a `try: catch:` to attach it `trial.fail()`, let the exception bubble up, or use `trial.being(catch_exceptions=True)` to have the current deprecated functionality.

The signature of `trial.fail()` was improved to allow the exception as a positional argument to make this easier. It will automatically fetch the stack trace and append it to itself.

For now, there is merely an annoying deprecation warning that will tell you to explicitly set your preferred behavior, until this default option can be changed.
---

```python
# Previously required idiom

# You would not expect this to eat your errors unless you've been told/read the docs
with trial.begin():  # catch_warnings=True (old default)
   raise ValueError()
   
# Linters might even complain code could never reach here

if trial.exception: # I wouldn't know I need to check this without having read about it
   trial.fail()
   
trial.success()
```

I suggested way is a lot more explicit and does not hide the details from the user by default. 

```python
with trial.begin():  # catch_warnings=False (new default)
    try:
   		raise ValueError()
   	except Exception as e:
   	    return trial.fail(e)

# Otherwise you can do things here...	   
trial.success()
```

There are a few changes that should be made to the optimization guide and this should be included along side it.