### PR TITLE
refactor(Metric, Trial): Cleanup of metrics and `Trial`

### DIFF
--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -190,14 +190,13 @@ at the end.
 from amltk.optimization import History, Trial, Metric
 from amltk.store import PathBucket
 
-bucket = PathBucket("my-bucket")
 metric = Metric("score", minimize=False, bounds=(0, 5))
 history = History()
 
 trials = [
-    Trial(name="trial-1", config={"x": 1.0}, bucket=bucket, metrics=[metric]),
-    Trial(name="trial-2", config={"x": 2.0}, bucket=bucket, metrics=[metric]),
-    Trial(name="trial-3", config={"x": 3.0}, bucket=bucket, metrics=[metric]),
+    Trial.create(name="trial-1", config={"x": 1.0}, metrics=[metric]),
+    Trial.create(name="trial-2", config={"x": 2.0}, metrics=[metric]),
+    Trial.create(name="trial-3", config={"x": 3.0}, metrics=[metric]),
 ]
 
 for trial in trials:
@@ -214,6 +213,7 @@ print(df)
 
 best = history.best()
 print(best)
+for t in trials: t.bucket.rmdir()  # markdown-exec: hide
 ```
 
 You can use the [`History.df()`][amltk.optimization.History.df] method to get a dataframe of the history and

--- a/docs/reference/optimization/history.md
+++ b/docs/reference/optimization/history.md
@@ -22,7 +22,7 @@ def quadratic(x):
 
 history = History()
 trials = [
-    Trial(name=f"trial_{count}", config={"x": i}, metrics=[loss])
+    Trial.create(name=f"trial_{count}", config={"x": i}, metrics=[loss])
     for count, i in enumerate(range(-5, 5))
 ]
 
@@ -91,7 +91,7 @@ print(history[last_report.name])
 
 ```python exec="true" source="material-block" result="python" session="ref-history"
 for report in history:
-    print(report.name, f"loss = {report.metrics['loss']}")
+    print(report.name, f"loss = {report.values['loss']}")
 ```
 
 ```python exec="true" source="material-block" result="python" session="ref-history"

--- a/examples/hpo.py
+++ b/examples/hpo.py
@@ -195,7 +195,7 @@ X_test, y_test = data["test"]
 
 bucket = PathBucket("example-hpo", clean=True, create=True)
 data_bucket = bucket / "data"
-bucket.store(
+data_bucket.store(
     {
         "X_train.csv": X_train,
         "X_val.csv": X_val,

--- a/examples/hpo_with_ensembling.py
+++ b/examples/hpo_with_ensembling.py
@@ -227,7 +227,7 @@ def target_function(
                 "traceback.txt": str(tb),
             },
         )
-        return trial.fail(e, tb)  # <!> (4)!
+        return trial.fail()  # <!> (4)!
 
     # Make our predictions with the model
     train_predictions = sklearn_pipeline.predict(X_train)
@@ -302,7 +302,7 @@ def create_ensemble(
         return Ensemble({}, [], {})
 
     validation_predictions = {
-        report.name: report.retrieve("val_probabilities.npy", where=bucket)
+        report.name: report.retrieve("val_probabilities.npy")
         for report in history
     }
     targets = bucket["y_val.npy"].load()
@@ -322,10 +322,7 @@ def create_ensemble(
         seed=seed,  # <!>
     )  # <!>
 
-    configs = {
-        name: history.find(name).retrieve("config.json", where=bucket)
-        for name in weights
-    }
+    configs = {name: history[name].retrieve("config.json") for name in weights}
     return Ensemble(weights=weights, trajectory=trajectory, configs=configs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ ignore = [
   "PLC1901", # "" can be simplified to be falsey
   "TCH003",  # Move stdlib import into TYPE_CHECKING
   "B010",    # Do not use `setattr`
+  "PD011",   # Use .to_numpy() instead of .values  (triggers on report.values)
   # These tend to be lighweight and confuse pyright
 ]
 

--- a/src/amltk/optimization/__init__.py
+++ b/src/amltk/optimization/__init__.py
@@ -1,5 +1,5 @@
 from amltk.optimization.history import History
-from amltk.optimization.metric import Metric
+from amltk.optimization.metric import Metric, MetricCollection
 from amltk.optimization.optimizer import Optimizer
 from amltk.optimization.trial import Trial
 
@@ -7,5 +7,6 @@ __all__ = [
     "Optimizer",
     "Trial",
     "Metric",
+    "MetricCollection",
     "History",
 ]

--- a/src/amltk/optimization/history.py
+++ b/src/amltk/optimization/history.py
@@ -24,7 +24,8 @@ used to keep a structured record of what occured with
     history = History()
 
     for x, y in zip([1, 2, 3], [4, 5, 6]):
-        trial = Trial(name="some-unique-name", config={"x": x, "y": y}, bucket=bucket, metrics=[loss])
+        name = f"trial_{x}_{y}"
+        trial = Trial.create(name=name, config={"x": x, "y": y}, bucket=bucket / name, metrics=[loss])
         report = target_function(trial)
         history.add(report)
 
@@ -98,7 +99,7 @@ class History(RichRenderable):
 
     metric = Metric("cost", minimize=True)
     trials = [
-        Trial(name=f"trial_{i}", config={"x": i}, metrics=[metric])
+        Trial.create(name=f"trial_{i}", config={"x": i}, metrics=[metric])
         for i in range(10)
     ]
     history = History()
@@ -236,7 +237,7 @@ class History(RichRenderable):
         from amltk.optimization import Trial, History, Metric
 
         metric = Metric("cost", minimize=True)
-        trials = [Trial(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
+        trials = [Trial.create(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
         history = History()
 
         for trial in trials:
@@ -300,7 +301,7 @@ class History(RichRenderable):
         from amltk.optimization import Trial, History, Metric
 
         metric = Metric("cost", minimize=True)
-        trials = [Trial(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
+        trials = [Trial.create(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
         history = History()
 
         for trial in trials:
@@ -308,9 +309,9 @@ class History(RichRenderable):
             report = trial.success(cost=x**2 - x*2 + 4)
             history.add(report)
 
-        filtered_history = history.filter(lambda report: report.metrics["cost"] < 10)
+        filtered_history = history.filter(lambda report: report.values["cost"] < 10)
         for report in filtered_history:
-            cost = report.metrics["cost"]
+            cost = report.values["cost"]
             print(f"{report.name}, {cost=}, {report}")
         ```
 
@@ -332,7 +333,7 @@ class History(RichRenderable):
         from amltk.optimization import Trial, History, Metric
 
         metric = Metric("cost", minimize=True)
-        trials = [Trial(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
+        trials = [Trial.create(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
         history = History()
 
         for trial in trials:
@@ -353,7 +354,7 @@ class History(RichRenderable):
         from amltk.optimization import Trial, History, Metric
 
         metric = Metric("cost", minimize=True)
-        trials = [Trial(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
+        trials = [Trial.create(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
         history = History()
 
         for trial in trials:
@@ -361,7 +362,7 @@ class History(RichRenderable):
             report = trial.fail(cost=x)
             history.add(report)
 
-        for below_5, history in history.groupby(lambda r: r.metrics["cost"] < 5).items():
+        for below_5, history in history.groupby(lambda r: r.values["cost"] < 5).items():
             print(f"{below_5=}, {len(history)=}")
         ```
 
@@ -397,7 +398,7 @@ class History(RichRenderable):
         from amltk.optimization import Trial, History, Metric
 
         metric = Metric("cost", minimize=True)
-        trials = [Trial(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
+        trials = [Trial.create(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
         history = History()
 
         for trial in trials:
@@ -410,7 +411,7 @@ class History(RichRenderable):
             .incumbents("cost", sortby=lambda r: r.reported_at)
         )
         for report in incumbents:
-            print(f"{report.metrics=}, {report.config=}")
+            print(f"{report.values=}, {report.config=}")
         ```
 
         Args:
@@ -462,7 +463,7 @@ class History(RichRenderable):
         from amltk.optimization import Trial, History, Metric
 
         metric = Metric("cost", minimize=True)
-        trials = [Trial(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
+        trials = [Trial.create(name=f"trial_{i}", config={"x": i}, metrics=[metric]) for i in range(10)]
         history = History()
 
         for trial in trials:
@@ -477,7 +478,7 @@ class History(RichRenderable):
         )
 
         for report in trace:
-            print(f"{report.metrics}, {report}")
+            print(f"{report.values}, {report}")
         ```
 
         Args:

--- a/src/amltk/optimization/history.py
+++ b/src/amltk/optimization/history.py
@@ -174,7 +174,10 @@ class History(RichRenderable):
                 _metric_name = metric.name
 
         _by = min if _metric_def.minimize else max
-        return _by(self.reports, key=lambda r: r.values[_metric_name])
+        return _by(
+            (r for r in self.reports if _metric_name in r.values),
+            key=lambda r: r.values[_metric_name],
+        )
 
     def add(self, report: Trial.Report | Iterable[Trial.Report]) -> None:
         """Adds a report or reports to the history.

--- a/src/amltk/optimization/history.py
+++ b/src/amltk/optimization/history.py
@@ -443,7 +443,7 @@ class History(RichRenderable):
             case str():
                 metric = self.metrics[key]
                 __op = operator.lt if metric.minimize else operator.gt  # type: ignore
-                op = lambda r1, r2: __op(r1.metrics[key], r2.metrics[key])
+                op = lambda r1, r2: __op(r1.values[key], r2.values[key])
             case _:
                 op = key
 

--- a/src/amltk/optimization/metric.py
+++ b/src/amltk/optimization/metric.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, ParamSpec
+from typing import TYPE_CHECKING, Any, Generic, Literal, ParamSpec
 from typing_extensions import Self, override
 
 if TYPE_CHECKING:
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
 
 
 P = ParamSpec("P")
+
+SklearnResponseMethods = Literal["predict", "predict_proba", "decision_function"]
 
 
 @dataclass(frozen=True)
@@ -86,8 +88,25 @@ class Metric(Generic[P]):
             )
         return self.fn(*args, **kwargs)
 
-    def as_sklearn_scorer(self) -> _Scorer:
-        """Convert a metric to a sklearn scorer."""
+    def as_scorer(
+        self,
+        *,
+        response_method: (
+            SklearnResponseMethods | Iterable[SklearnResponseMethods] | None
+        ) = None,
+        **scorer_kwargs: Any,
+    ) -> _Scorer:
+        """Convert a metric to a sklearn scorer.
+
+        Args:
+            response_method: The response method to use for the scorer.
+                This can be a single method or an iterable of methods.
+            scorer_kwargs: Additional keyword arguments to pass to the
+                scorer during the call. Forwards to [`sklearn.metrics.make_scorer`][].
+
+        Returns:
+            The sklearn scorer.
+        """
         from sklearn.metrics import get_scorer, make_scorer
 
         match self.fn:
@@ -100,7 +119,12 @@ class Metric(Generic[P]):
                         " Please provide a function to `Metric(fn=...)`.",
                     ) from e
             case fn:
-                return make_scorer(fn, greater_is_better=not self.minimize)
+                return make_scorer(
+                    fn,
+                    greater_is_better=not self.minimize,
+                    response_method=response_method,
+                    **scorer_kwargs,
+                )
 
     @override
     def __str__(self) -> str:
@@ -146,94 +170,42 @@ class Metric(Generic[P]):
         return cls(name=name, minimize=minimize, bounds=bounds)
 
     @property
-    def worst(self) -> Metric.Value:
+    def worst(self) -> float:
         """The worst possible value of the metric."""
-        if self.bounds:
-            v = self.bounds[1] if self.minimize else self.bounds[0]
-            return self.as_value(v)
+        if self.bounds is not None:
+            return self.bounds[1] if self.minimize else self.bounds[0]
 
-        v = float("inf") if self.minimize else float("-inf")
-        return self.as_value(v)
+        return float("inf") if self.minimize else float("-inf")
 
     @property
-    def optimal(self) -> Metric.Value:
+    def optimal(self) -> float:
         """The optimal value of the metric."""
         if self.bounds:
-            v = self.bounds[0] if self.minimize else self.bounds[1]
-            return self.as_value(v)
-        v = float("-inf") if self.minimize else float("inf")
-        return self.as_value(v)
+            return self.bounds[0] if self.minimize else self.bounds[1]
 
-    def as_value(self, value: float | int) -> Metric.Value:
-        """Convert a value to an metric value."""
-        return Metric.Value(metric=self, value=float(value))
+        return float("-inf") if self.minimize else float("inf")
 
-    @dataclass(frozen=True, order=True)
-    class Value:
-        """A recorded value of an metric."""
+    def distance_to_optimal(self, v: float, /) -> float | None:
+        """The distance to the optimal value, using the bounds if possible."""
+        match self.bounds:
+            case None:
+                return None
+            case (lower, upper) if lower <= v <= upper:
+                if self.minimize:
+                    return abs(v - lower)
+                return abs(v - upper)
+            case (lower, upper):
+                raise ValueError(f"Value {v} is not within {self.bounds=}")
+            case _:
+                raise ValueError(f"Invalid {self.bounds=}")
 
-        metric: Metric = field(compare=False, hash=True)
-        """The metric."""
+    def loss(self, v: float, /) -> float:
+        """Convert a value to a loss."""
+        return float(v) if self.minimize else -float(v)
 
-        value: float = field(compare=True, hash=True)
-        """The value of the metric."""
-
-        @property
-        def minimize(self) -> bool:
-            """Whether to minimize or maximize the metric."""
-            return self.metric.minimize
-
-        @property
-        def bounds(self) -> tuple[float, float] | None:
-            """Whether to minimize or maximize the metric."""
-            return self.metric.bounds
-
-        @property
-        def name(self) -> str:
-            """The name of the metric."""
-            return self.metric.name
-
-        @property
-        def loss(self) -> float:
-            """Convert a value to a loss."""
-            if self.minimize:
-                return float(self.value)
-            return -float(self.value)
-
-        @property
-        def score(self) -> float:
-            """Convert a value to a score."""
-            if self.minimize:
-                return -float(self.value)
-            return float(self.value)
-
-        @property
-        def distance_to_optimal(self) -> float | None:
-            """The distance to the optimal value, using the bounds if possible."""
-            match self.bounds:
-                case None:
-                    return None
-                case (lower, upper) if lower <= self.value <= upper:
-                    if self.minimize:
-                        return abs(self.value - lower)
-                    return abs(self.value - upper)
-                case (lower, upper):
-                    raise ValueError(f"Value {self.value} is not within {self.bounds=}")
-
-            return None
-
-        def __float__(self) -> float:
-            """Convert a value to a float."""
-            return float(self.value)
-
-        @override
-        def __eq__(self, __value: object) -> bool:
-            """Check if two values are equal."""
-            if isinstance(__value, Metric.Value):
-                return self.value == __value.value
-            if isinstance(__value, float | int):
-                return self.value == float(__value)
-            return NotImplemented
+    def score(self, v: float, /) -> float:
+        """Convert a value to a score."""
+        return -float(v) if self.minimize else float(v)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -255,12 +227,32 @@ class MetricCollection(Mapping[str, Metric]):
     def __iter__(self) -> Iterator[str]:
         return iter(self.metrics)
 
-    def as_sklearn(self, *, raise_exc: bool = True) -> _MultimetricScorer:
+    def as_sklearn_scorer(
+        self,
+        *,
+        response_methods: (
+            Mapping[str, SklearnResponseMethods | Iterable[SklearnResponseMethods]]
+            | None
+        ) = None,
+        scorer_kwargs: Mapping[str, Mapping[str, Any]] | None = None,
+        raise_exc: bool = True,
+    ) -> _MultimetricScorer:
         """Convert this collection to a sklearn scorer."""
         from sklearn.metrics._scorer import _MultimetricScorer
 
-        scorers = {k: v.as_sklearn_scorer() for k, v in self.items()}
+        rms = response_methods or {}
+        skwargs = scorer_kwargs or {}
+
+        scorers = {
+            k: v.as_scorer(response_method=rms.get(k), **skwargs.get(k, {}))
+            for k, v in self.items()
+        }
         return _MultimetricScorer(scorers=scorers, raise_exc=raise_exc)
+
+    @classmethod
+    def from_empty(cls) -> MetricCollection:
+        """Create an empty metric collection."""
+        return cls(metrics={})
 
     @classmethod
     def from_collection(

--- a/src/amltk/optimization/metric.py
+++ b/src/amltk/optimization/metric.py
@@ -217,13 +217,14 @@ class Metric(Generic[P]):
         """
         match self.bounds:
             # If both sides are finite, we can 0-1 normalize
-            case (lower, upper) if not (np.isinf(lower) or np.isinf(upper)):
+            case (lower, upper) if not np.isinf(lower) and not np.isinf(upper):
                 cost = (v - lower) / (upper - lower)
+                cost = 1 - cost if self.minimize is False else cost
             # No bounds or one unbounded bound, we can't normalize
             case _:
-                cost = v
+                cost = v if self.minimize else -v
 
-        return cost if self.minimize else -cost
+        return cost
 
     def loss(self, v: float, /) -> float:
         """Convert a value to a loss."""

--- a/src/amltk/optimization/metric.py
+++ b/src/amltk/optimization/metric.py
@@ -5,13 +5,18 @@ A `Metric` is defined by a `.name: str` and whether it is better to `.minimize: 
 the metric. Further, you can specify `.bounds: tuple[lower, upper]` which can
 help optimizers and other code know how to treat metrics.
 
-To easily convert between [`loss`][amltk.optimization.Metric.Value.loss],
-[`score`][amltk.optimization.Metric.Value.score] of a
-a value in a [`Metric.Value`][amltk.optimization.Metric.Value] object.
+To easily convert between `loss` and
+`score` of some value you can use the [`loss()`][amltk.optimization.Metric.loss]
+and [`score()`][amltk.optimization.Metric.score] methods.
 
-If the metric is bounded, you can also get the
-[`distance_to_optimal`][amltk.optimization.Metric.Value.distance_to_optimal]
-which is the distance to the optimal value.
+If the metric is bounded, you can also make use of the
+[`distance_to_optimal()`][amltk.optimization.Metric.distance_to_optimal]
+function which is the distance to the optimal value.
+
+In the case of optimization, we provide a
+[`normalized_loss()`][amltk.optimization.Metric.normalized_loss] which
+normalized the value to be a minimization loss, that is also bounded
+if the metric itself is bounded.
 
 ```python exec="true" source="material-block" result="python"
 from amltk.optimization import Metric
@@ -27,7 +32,7 @@ print(f"Score: {acc_value.score}")  # Something that can be maximized
 """
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, ParamSpec
 from typing_extensions import Self, override
@@ -94,7 +99,7 @@ class Metric(Generic[P]):
         self,
         *,
         response_method: (
-            SklearnResponseMethods | Iterable[SklearnResponseMethods] | None
+            SklearnResponseMethods | Sequence[SklearnResponseMethods] | None
         ) = None,
         **scorer_kwargs: Any,
     ) -> _Scorer:
@@ -252,7 +257,7 @@ class MetricCollection(Mapping[str, Metric]):
         self,
         *,
         response_methods: (
-            Mapping[str, SklearnResponseMethods | Iterable[SklearnResponseMethods]]
+            Mapping[str, SklearnResponseMethods | Sequence[SklearnResponseMethods]]
             | None
         ) = None,
         scorer_kwargs: Mapping[str, Mapping[str, Any]] | None = None,

--- a/src/amltk/optimization/metric.py
+++ b/src/amltk/optimization/metric.py
@@ -21,12 +21,12 @@ if the metric itself is bounded.
 ```python exec="true" source="material-block" result="python"
 from amltk.optimization import Metric
 
-acc = Metric("accuracy", minimize=False, bounds=(0.0, 1.0))
+acc = Metric("accuracy", minimize=False, bounds=(0, 100))
 
-acc_value = acc.as_value(0.9)
-print(f"Cost: {acc_value.distance_to_optimal}")  # Distance to optimal.
-print(f"Loss: {acc_value.loss}")  # Something that can be minimized
-print(f"Score: {acc_value.score}")  # Something that can be maximized
+print(f"Distance: {acc.distance_to_optimal(90)}")  # Distance to optimal.
+print(f"Loss: {acc.loss(90)}")  # Something that can be minimized
+print(f"Score: {acc.score(90)}")  # Something that can be maximized
+print(f"Normalized loss: {acc.normalized_loss(90)}")  # Normalized loss
 ```
 
 """

--- a/src/amltk/optimization/metric.py
+++ b/src/amltk/optimization/metric.py
@@ -265,14 +265,14 @@ class MetricCollection(Mapping[str, Metric]):
     @classmethod
     def from_collection(
         cls,
-        metrics: Metric | Iterable[Metric] | MetricCollection,
+        metrics: Metric | Iterable[Metric] | Mapping[str, Metric],
     ) -> MetricCollection:
         """Create a metric collection from an iterable of metrics."""
         match metrics:
             case Metric():
                 return cls(metrics={metrics.name: metrics})
-            case MetricCollection():
-                return MetricCollection(metrics=metrics.metrics)
+            case Mapping():
+                return MetricCollection(metrics={m.name: m for m in metrics.values()})
             case Iterable():
                 return cls(metrics={m.name: m for m in metrics})  # type: ignore
             case _:

--- a/src/amltk/optimization/optimizer.py
+++ b/src/amltk/optimization/optimizer.py
@@ -34,6 +34,7 @@ from typing_extensions import Self
 
 from more_itertools import all_unique
 
+from amltk.optimization.metric import MetricCollection
 from amltk.store.paths.path_bucket import PathBucket
 
 if TYPE_CHECKING:
@@ -56,7 +57,7 @@ class Optimizer(Generic[I]):
     `tell` to inform the optimizer of the report from that trial.
     """
 
-    metrics: Sequence[Metric]
+    metrics: MetricCollection
     """The metrics to optimize."""
 
     bucket: PathBucket
@@ -81,7 +82,7 @@ class Optimizer(Generic[I]):
                 f"Got {metrics} with names {[metric.name for metric in metrics]}",
             )
 
-        self.metrics = metrics
+        self.metrics = MetricCollection.from_collection(metrics)
         self.bucket = (
             bucket
             if bucket is not None

--- a/src/amltk/optimization/optimizers/neps.py
+++ b/src/amltk/optimization/optimizers/neps.py
@@ -465,7 +465,7 @@ class NEPSOptimizer(Optimizer[NEPSTrialInfo]):
             info=info,
             seed=self.seed,
             bucket=self.bucket,
-            metrics=metrics,
+            metrics={m.name: m for m in metrics},
         )
         logger.debug(f"Asked for trial {trial.name}")
         return trial

--- a/src/amltk/optimization/optimizers/neps.py
+++ b/src/amltk/optimization/optimizers/neps.py
@@ -133,7 +133,6 @@ from typing_extensions import override
 import metahyper.api
 from ConfigSpace import ConfigurationSpace
 from metahyper import instance_from_map
-from more_itertools import first_true
 from neps.optimizers import SearcherMapping
 from neps.search_spaces.parameter import Parameter
 from neps.search_spaces.search_space import SearchSpace, pipeline_space_from_configspace
@@ -459,12 +458,12 @@ class NEPSOptimizer(Optimizer[NEPSTrialInfo]):
             case cost_metric:
                 metrics = [self.loss_metric, cost_metric]
 
-        trial = Trial(
+        trial = Trial.create(
             name=info.name,
             config=info.config,
             info=info,
             seed=self.seed,
-            bucket=self.bucket,
+            bucket=self.bucket / info.name,
             metrics={m.name: m for m in metrics},
         )
         logger.debug(f"Asked for trial {trial.name}")
@@ -482,20 +481,10 @@ class NEPSOptimizer(Optimizer[NEPSTrialInfo]):
         assert info is not None
 
         # Get a metric result
-        metric_result = first_true(
-            report.metric_values,
-            pred=lambda value: value.metric.name == self.loss_metric.name,
-            default=self.loss_metric.worst,
-        )
+        loss = report.values.get(self.loss_metric.name, self.loss_metric.worst)
+        normalized_loss = self.loss_metric.normalized_loss(loss)
 
-        # Convert metric result to a minimization loss
-        neps_loss: float
-        if (_loss := metric_result.distance_to_optimal) is not None:
-            neps_loss = _loss
-        else:
-            neps_loss = metric_result.loss
-
-        result: dict[str, Any] = {"loss": neps_loss}
+        result: dict[str, Any] = {"loss": normalized_loss}
 
         metadata: dict[str, Any]
         if (
@@ -512,13 +501,9 @@ class NEPSOptimizer(Optimizer[NEPSTrialInfo]):
             metadata = {}
 
         if self.cost_metric is not None:
-            cost_metric: Metric = self.cost_metric
-            _cost = first_true(
-                report.metric_values,
-                pred=lambda value: value.metric.name == cost_metric.name,
-                default=self.cost_metric.worst,
-            )
-            cost = _cost.value
+            cost = report.values.get(self.cost_metric.name, self.cost_metric.worst)
+
+            # We don't normalize here
             result["cost"] = cost
 
             # If it's a budget aware optimizer

--- a/src/amltk/optimization/optimizers/optuna.py
+++ b/src/amltk/optimization/optimizers/optuna.py
@@ -192,7 +192,6 @@ class OptunaOptimizer(Optimizer[OptunaTrial]):
         super().__init__(bucket=bucket, metrics=metrics)
         self.seed = amltk.randomness.as_int(seed)
         self.study = study
-        self.metrics = metrics
         self.space = space
 
     @classmethod
@@ -293,14 +292,13 @@ class OptunaOptimizer(Optimizer[OptunaTrial]):
         config = optuna_trial.params
         trial_number = optuna_trial.number
         unique_name = f"{trial_number=}"
-        metrics = [self.metrics] if isinstance(self.metrics, Metric) else self.metrics
         return Trial(
             name=unique_name,
             seed=self.seed,
             config=config,
             info=optuna_trial,
             bucket=self.bucket,
-            metrics=metrics,
+            metrics={m.name: m for m in self.metrics},
         )
 
     @override

--- a/src/amltk/optimization/optimizers/optuna.py
+++ b/src/amltk/optimization/optimizers/optuna.py
@@ -111,7 +111,6 @@ from typing import TYPE_CHECKING, Any, overload
 from typing_extensions import Self, override
 
 import optuna
-from more_itertools import first_true
 from optuna.samplers import BaseSampler, NSGAIISampler, TPESampler
 from optuna.study import Study, StudyDirection
 from optuna.trial import (
@@ -194,6 +193,7 @@ class OptunaOptimizer(Optimizer[OptunaTrial]):
         self.study = study
         self.space = space
 
+    @override
     @classmethod
     def create(
         cls,
@@ -292,13 +292,13 @@ class OptunaOptimizer(Optimizer[OptunaTrial]):
         config = optuna_trial.params
         trial_number = optuna_trial.number
         unique_name = f"{trial_number=}"
-        return Trial(
+        return Trial.create(
             name=unique_name,
             seed=self.seed,
             config=config,
             info=optuna_trial,
-            bucket=self.bucket,
-            metrics={m.name: m for m in self.metrics},
+            bucket=self.bucket / unique_name,
+            metrics=self.metrics,
         )
 
     @override
@@ -316,31 +316,15 @@ class OptunaOptimizer(Optimizer[OptunaTrial]):
                 # NOTE: Can't tell any values if the trial crashed or failed
                 self.study.tell(trial=trial, state=TrialState.FAIL)
             case Trial.Status.SUCCESS:
-                match self.metrics:
-                    case [metric]:
-                        metric_value: Metric.Value = first_true(
-                            report.metric_values,
-                            pred=lambda m: m.metric == metric,
-                            default=metric.worst,
-                        )
-                        self.study.tell(
-                            trial=trial,
-                            state=TrialState.COMPLETE,
-                            values=metric_value.value,
-                        )
-                    case metrics:
-                        # NOTE: We need to make sure that there sorted in the order
-                        # that Optuna expects, with any missing metrics filled in
-                        _lookup = {v.metric.name: v for v in report.metric_values}
-                        values = [
-                            _lookup.get(metric.name, metric.worst).value
-                            for metric in metrics
-                        ]
-                        self.study.tell(
-                            trial=trial,
-                            state=TrialState.COMPLETE,
-                            values=values,
-                        )
+                values = {
+                    name: report.values.get(name, metric.worst)
+                    for name, metric in self.metrics.items()
+                }
+                v: list[float] = list(values.values())
+                if len(v) == 1:
+                    self.study.tell(trial=trial, state=TrialState.COMPLETE, values=v[0])
+                else:
+                    self.study.tell(trial=trial, state=TrialState.COMPLETE, values=v)
 
     @override
     @classmethod

--- a/src/amltk/optimization/optimizers/smac.py
+++ b/src/amltk/optimization/optimizers/smac.py
@@ -318,7 +318,7 @@ class SMACOptimizer(Optimizer[SMACTrialInfo]):
             seed=seed,
             fidelities=trial_fids,
             bucket=self.bucket,
-            metrics=self.metrics,
+            metrics={m.name: m for m in self.metrics},
         )
         logger.debug(f"Asked for trial {trial.name}")
         return trial

--- a/src/amltk/optimization/optimizers/smac.py
+++ b/src/amltk/optimization/optimizers/smac.py
@@ -333,11 +333,14 @@ class SMACOptimizer(Optimizer[SMACTrialInfo]):
         for name, metric in self.metrics.items():
             value = report.values.get(metric.name)
             if value is None:
-                raise ValueError(
-                    f"Could not find metric '{metric.name}' in report values."
-                    " Make sure you use `trial.success()` in your target function."
-                    " So that we can report the metric value to SMAC.",
-                )
+                if report.status == Trial.Status.SUCCESS:
+                    raise ValueError(
+                        f"Could not find metric '{metric.name}' in report values."
+                        " Make sure you use `trial.success()` in your target function."
+                        " So that we can report the metric value to SMAC.",
+                    )
+                value = metric.worst
+
             costs[name] = metric.normalized_loss(value)
 
         logger.debug(f"Reporting for trial {report.trial.name} with costs: {costs}")

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -40,6 +40,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, overload
 from typing_extensions import ParamSpec, Self, override
 
@@ -274,7 +275,7 @@ class Trial(RichRenderable, Generic[I]):
         seed: int | None = None,
         fidelities: Mapping[str, Any] | None = None,
         profiler: Profiler | None = None,
-        bucket: PathBucket | None = None,
+        bucket: str | Path | PathBucket | None = None,
         summary: MutableMapping[str, Any] | None = None,
         storage: set[Hashable] | None = None,
         extras: MutableMapping[str, Any] | None = None,
@@ -313,7 +314,15 @@ class Trial(RichRenderable, Generic[I]):
             info=info,
             seed=seed,
             fidelities=fidelities if fidelities is not None else {},
-            bucket=bucket if bucket is not None else PathBucket("unknown-trial-bucket"),
+            bucket=(
+                bucket
+                if isinstance(bucket, PathBucket)
+                else (
+                    PathBucket(bucket)
+                    if bucket is not None
+                    else PathBucket(f"trial-{name}-{datetime.now().isoformat()}")
+                )
+            ),
             summary=summary if summary is not None else {},
             storage=storage if storage is not None else set(),
             extras=extras if extras is not None else {},

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -40,7 +40,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, overload
 from typing_extensions import ParamSpec, Self, override
 
@@ -52,7 +51,7 @@ from amltk._richutil.renderable import RichRenderable
 from amltk._util import parse_timestamp_object
 from amltk.optimization.metric import Metric, MetricCollection
 from amltk.profiling import Memory, Profile, Profiler, Timer
-from amltk.store import Bucket, PathBucket
+from amltk.store import PathBucket
 
 if TYPE_CHECKING:
     from rich.console import RenderableType
@@ -569,8 +568,9 @@ class Trial(RichRenderable, Generic[I]):
             A dict from the key to whether it was deleted or not.
         """  # noqa: E501
         # If not a Callable, we convert to a path bucket
-        self.bucket.remove(items)
+        removed = self.bucket.remove(items)
         self.storage.difference_update(items)
+        return removed
 
     def copy(self) -> Self:
         """Create a copy of the trial.
@@ -862,7 +862,7 @@ class Trial(RichRenderable, Generic[I]):
                 "reported_at": self.reported_at,
             }
             if metrics:
-                for metric_name, value in self.values:
+                for metric_name, value in self.values.items():
                     metric_def = self.metrics[metric_name]
                     items[f"metric:{metric_def}"] = value
             if summary:

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -113,7 +113,11 @@ class Trial(RichRenderable, Generic[I]):
             return trial.success(cost=cost)
 
         # ... usually obtained from an optimizer
-        trial = Trial(name="some-unique-name", config={"x": 1, "y": 2}, metrics=[cost])
+        trial = Trial.create(
+            name="some-unique-name",
+            config={"x": 1, "y": 2},
+            metrics=[cost]
+        )
 
         report = target_function(trial)
         print(report.df())
@@ -160,7 +164,7 @@ class Trial(RichRenderable, Generic[I]):
             from amltk.optimization import Trial, Metric
 
             # Gotten from some optimizer usually, i.e. via `optimizer.ask()`
-            trial = Trial(
+            trial = Trial.create(
                 name="example_trial",
                 config={"param": 42},
                 metrics=[Metric(name="accuracy", minimize=False)]
@@ -194,7 +198,7 @@ class Trial(RichRenderable, Generic[I]):
         ```python exec="true" source="material-block" result="python" title="profile"
         from amltk.optimization import Trial
 
-        trial = Trial(name="some-unique-name", config={})
+        trial = Trial.create(name="some-unique-name", config={})
 
         # ... somewhere where you've begun your trial.
         with trial.profile("some_interval"):
@@ -351,7 +355,7 @@ class Trial(RichRenderable, Generic[I]):
         from amltk.optimization import Trial
         import time
 
-        trial = Trial(name="trial", config={"x": 1})
+        trial = Trial.create(name="trial", config={"x": 1})
 
         with trial.profile("some_interval"):
             # Do some work
@@ -386,7 +390,7 @@ class Trial(RichRenderable, Generic[I]):
 
         loss_metric = Metric("loss", minimize=True)
 
-        trial = Trial(name="trial", config={"x": 1}, metrics=[loss_metric])
+        trial = Trial.create(name="trial", config={"x": 1}, metrics=[loss_metric])
         report = trial.success(loss=1)
 
         print(report)
@@ -443,14 +447,14 @@ class Trial(RichRenderable, Generic[I]):
         from amltk.optimization import Trial, Metric
 
         loss = Metric("loss", minimize=True, bounds=(0, 1_000))
-        trial = Trial(name="trial", config={"x": 1}, metrics=[loss])
+        trial = Trial.create(name="trial", config={"x": 1}, metrics=[loss])
 
         try:
             raise ValueError("This is an error")  # Something went wrong
         except Exception as error:
             report = trial.fail(error)
 
-        print(report.metrics)
+        print(report.values)
         print(report)
         ```
 
@@ -524,7 +528,7 @@ class Trial(RichRenderable, Generic[I]):
         from amltk.optimization import Trial
         from amltk.store import PathBucket
 
-        trial = Trial(name="trial", config={"x": 1}, bucket=PathBucket("my-trial"))
+        trial = Trial.create(name="trial", config={"x": 1}, bucket=PathBucket("my-trial"))
         trial.store({"config.json": trial.config})
         print(trial.storage)
         ```
@@ -547,7 +551,7 @@ class Trial(RichRenderable, Generic[I]):
         from amltk.store import PathBucket
 
         bucket = PathBucket("results")
-        trial = Trial(name="trial", config={"x": 1}, info={}, bucket=bucket)
+        trial = Trial.create(name="trial", config={"x": 1}, info={}, bucket=bucket)
 
         trial.store({"config.json": trial.config})
         trial.delete_from_storage(items=["config.json"])
@@ -562,7 +566,7 @@ class Trial(RichRenderable, Generic[I]):
         from amltk.store import PathBucket
 
         bucket = PathBucket("results")
-        trial = Trial(name="trial", config={"x": 1}, bucket=bucket)
+        trial = Trial.create(name="trial", config={"x": 1}, bucket=bucket)
 
         trial.store({"config.json": trial.config})
         trial.delete_from_storage(items=["config.json"])
@@ -607,7 +611,7 @@ class Trial(RichRenderable, Generic[I]):
         bucket = PathBucket("results")
 
         # Create a trial, normally done by an optimizer
-        trial = Trial(name="trial", config={"x": 1}, bucket=bucket)
+        trial = Trial.create(name="trial", config={"x": 1}, bucket=bucket)
 
         trial.store({"config.json": trial.config})
         config = trial.retrieve("config.json")
@@ -746,7 +750,7 @@ class Trial(RichRenderable, Generic[I]):
 
         loss = Metric("loss", minimize=True)
 
-        trial = Trial(name="trial", config={"x": 1}, metrics=[loss])
+        trial = Trial.create(name="trial", config={"x": 1}, metrics=[loss])
 
         with trial.profile("fitting"):
             # Do some work
@@ -902,7 +906,7 @@ class Trial(RichRenderable, Generic[I]):
 
             bucket = PathBucket("results")
 
-            trial = Trial(name="trial", config={"x": 1}, bucket=bucket)
+            trial = Trial.create(name="trial", config={"x": 1}, bucket=bucket)
 
             trial.store({"config.json": trial.config})
             report = trial.success()

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -117,7 +117,7 @@ class OnBeginCallbackSignature(Protocol):
         # You can do early stopping based on a target metric
         @task.on_result
         def stop_if_target_reached(_: Future, report: Trial.Report) -> None:
-            score = report.metrics["accuracy"]
+            score = report.values["accuracy"]
             if score >= 0.95:
                 scheduler.stop(stop_msg="Target reached!"))
 
@@ -127,7 +127,7 @@ class OnBeginCallbackSignature(Protocol):
 
         @task.on_result
         def stop_if_no_improvement_for_n_runs(_: Future, report: Trial.Report) -> None:
-            score = report.metrics["accuracy"]
+            score = report.values["accuracy"]
             if score > last_score:
                 n = 0
                 last_score = score

--- a/src/amltk/scheduling/plugins/pynisher.py
+++ b/src/amltk/scheduling/plugins/pynisher.py
@@ -367,7 +367,7 @@ class PynisherPlugin(Plugin):
                     )
 
                     # Will auto-detect
-                    trial = Trial(...)
+                    trial = Trial.create(...)
                     task_one.submit(trial, ...)
                     task_two.submit(..., trial=trial)
 

--- a/src/amltk/store/paths/path_bucket.py
+++ b/src/amltk/store/paths/path_bucket.py
@@ -136,6 +136,7 @@ class PathBucket(Bucket[str, Path]):
         if isinstance(path, str):
             path = Path(path)
         elif isinstance(path, PathBucket):
+            # TODO: Should we inherit the loaders?
             path = path.path
 
         if clean and path.exists():

--- a/tests/optimizers/test_history.py
+++ b/tests/optimizers/test_history.py
@@ -56,34 +56,34 @@ def case_empty() -> list[Trial.Report]:
 
 @case(tags=["success"])
 def case_one_report_success() -> list[Trial.Report]:
-    trial: Trial = Trial(name="trial_1", config={"x": 1}, metrics=metrics)
+    trial: Trial = Trial.create(name="trial_1", config={"x": 1}, metrics=metrics)
     return eval_trial(trial)
 
 
 @case(tags=["fail"])
 def case_one_report_fail() -> list[Trial.Report]:
-    trial: Trial = Trial(name="trial_1", config={"x": 1}, metrics=metrics)
+    trial: Trial = Trial.create(name="trial_1", config={"x": 1}, metrics=metrics)
     return eval_trial(trial, fail=100)
 
 
 @case(tags=["crash"])
 def case_one_report_crash() -> list[Trial.Report]:
-    trial: Trial = Trial(name="trial_1", config={"x": 1}, metrics=metrics)
+    trial: Trial = Trial.create(name="trial_1", config={"x": 1}, metrics=metrics)
     return eval_trial(trial, crash=ValueError("Some Error"))
 
 
 @case(tags=["success", "fail", "crash"])
 def case_many_report() -> list[Trial.Report]:
     success_trials: list[Trial] = [
-        Trial(name=f"trial_{i+6}", config={"x": i}, metrics=metrics)
+        Trial.create(name=f"trial_{i+6}", config={"x": i}, metrics=metrics)
         for i in range(-5, 5)
     ]
     fail_trials: list[Trial] = [
-        Trial(name=f"trial_{i+16}", config={"x": i}, metrics=metrics)
+        Trial.create(name=f"trial_{i+16}", config={"x": i}, metrics=metrics)
         for i in range(-5, 5)
     ]
     crash_trials: list[Trial] = [
-        Trial(name=f"trial_{i+26}", config={"x": i}, metrics=metrics)
+        Trial.create(name=f"trial_{i+26}", config={"x": i}, metrics=metrics)
         for i in range(-5, 5)
     ]
 
@@ -167,7 +167,7 @@ def test_trace_sortby(reports: list[Trial.Report]) -> None:
 
 def test_history_sortby() -> None:
     trials: list[Trial] = [
-        Trial(name=f"trial_{i+6}", metrics=metrics, config={"x": i})
+        Trial.create(name=f"trial_{i+6}", metrics=metrics, config={"x": i})
         for i in range(-5, 5)
     ]
 
@@ -183,7 +183,7 @@ def test_history_sortby() -> None:
 
     trace_loss = history.sortby("loss")
     assert len(trace_loss) == len(trials)
-    losses = [r.metrics["loss"] for r in trace_loss]
+    losses = [r.values["loss"] for r in trace_loss]
     assert sorted(losses) == losses
 
     trace_other = history.filter(lambda report: "other_loss" in report.summary).sortby(
@@ -200,7 +200,11 @@ def test_history_incumbents() -> None:
     m1 = Metric("score", minimize=False)
     m2 = Metric("loss", minimize=True)
     trials: list[Trial] = [
-        Trial(name=f"trial_{i+6}", metrics={"score": m1, "loss": m2}, config={"x": i})
+        Trial.create(
+            name=f"trial_{i+6}",
+            metrics={"score": m1, "loss": m2},
+            config={"x": i},
+        )
         for i in [0, -1, 2, -3, 4, -5, 6, -7, 8, -9]
     ]
     history = History()

--- a/tests/optimizers/test_history.py
+++ b/tests/optimizers/test_history.py
@@ -9,7 +9,7 @@ from pytest_cases import case, parametrize_with_cases
 
 from amltk.optimization import History, Metric, Trial
 
-metrics = [Metric("loss", minimize=True)]
+metrics = {"loss": Metric("loss", minimize=True)}
 
 
 def quadratic(x: float) -> float:
@@ -200,7 +200,7 @@ def test_history_incumbents() -> None:
     m1 = Metric("score", minimize=False)
     m2 = Metric("loss", minimize=True)
     trials: list[Trial] = [
-        Trial(name=f"trial_{i+6}", metrics=[m1, m2], config={"x": i})
+        Trial(name=f"trial_{i+6}", metrics={"score": m1, "loss": m2}, config={"x": i})
         for i in [0, -1, 2, -3, 4, -5, 6, -7, 8, -9]
     ]
     history = History()

--- a/tests/optimizers/test_history.py
+++ b/tests/optimizers/test_history.py
@@ -216,19 +216,19 @@ def test_history_incumbents() -> None:
 
     hist_1 = history.incumbents("loss", ffill=True)
     expected_1 = [0, -1, -1, -3, -3, -5, -5, -7, -7, -9]
-    assert [r.metrics["loss"] for r in hist_1] == expected_1
+    assert [r.values["loss"] for r in hist_1] == expected_1
 
     hist_2 = history.incumbents("loss", ffill=False)
     expected_2 = [0, -1, -3, -5, -7, -9]
-    assert [r.metrics["loss"] for r in hist_2] == expected_2
+    assert [r.values["loss"] for r in hist_2] == expected_2
 
     hist_3 = history.incumbents("score", ffill=True)
     expected_3 = [0, 0, 2, 2, 4, 4, 6, 6, 8, 8]
-    assert [r.metrics["score"] for r in hist_3] == expected_3
+    assert [r.values["score"] for r in hist_3] == expected_3
 
     hist_4 = history.incumbents("score", ffill=False)
     expected_4 = [0, 2, 4, 6, 8]
-    assert [r.metrics["score"] for r in hist_4] == expected_4
+    assert [r.values["score"] for r in hist_4] == expected_4
 
 
 @parametrize_with_cases("reports", cases=".")

--- a/tests/optimizers/test_history.py
+++ b/tests/optimizers/test_history.py
@@ -196,6 +196,26 @@ def test_history_sortby() -> None:
     assert sorted(losses) == losses
 
 
+def test_history_best() -> None:
+    trials: list[Trial] = [
+        Trial.create(name=f"trial_{i}", metrics=metrics, config={"x": i})
+        for i in range(10)
+    ]
+
+    history = History()
+
+    for trial in trials:
+        # This should have been the best but failed
+        if trial.name == "trial_0":
+            history.add(trial.fail())
+        else:
+            history.add(trial.success(loss=trial.config["x"]))
+
+    best = history.best("loss")
+    assert best.name == "trial_1"
+    assert best.values["loss"] == 1
+
+
 def test_history_incumbents() -> None:
     m1 = Metric("score", minimize=False)
     m2 = Metric("loss", minimize=True)

--- a/tests/optimizers/test_metric.py
+++ b/tests/optimizers/test_metric.py
@@ -17,6 +17,7 @@ class MetricTest:
     expected_loss: float
     expected_distance_from_optimal: float | None
     expected_score: float
+    expected_normalized_loss: float
     expected_str: str
 
 
@@ -28,6 +29,7 @@ def case_metric_score_bounded() -> MetricTest:
         value=0.3,
         expected_loss=-0.3,
         expected_distance_from_optimal=0.7,
+        expected_normalized_loss=0.7,
         expected_score=0.3,
         expected_str="score_bounded [0.0, 1.0] (maximize)",
     )
@@ -41,6 +43,7 @@ def case_metric_score_unbounded() -> MetricTest:
         value=0.3,
         expected_loss=-0.3,
         expected_distance_from_optimal=None,
+        expected_normalized_loss=-0.3,
         expected_score=0.3,
         expected_str="score_unbounded (maximize)",
     )
@@ -54,6 +57,7 @@ def case_metric_loss_unbounded() -> MetricTest:
         value=0.8,
         expected_loss=0.8,
         expected_distance_from_optimal=None,
+        expected_normalized_loss=0.8,
         expected_score=-0.8,
         expected_str="loss_unbounded (minimize)",
     )
@@ -67,6 +71,7 @@ def case_metric_loss_bounded() -> MetricTest:
         value=0.8,
         expected_loss=0.8,
         expected_distance_from_optimal=1.8,
+        expected_normalized_loss=0.9,
         expected_score=-0.8,
         expected_str="loss_bounded [-1.0, 1.0] (minimize)",
     )
@@ -135,10 +140,17 @@ def test_distance_to_optimal_is_always_positive_for_bounded(C: MetricTest) -> No
     assert C.metric.distance_to_optimal(C.value) >= 0
 
 
+@parametrize_with_cases(argnames="C", cases=".")
+def test_normalized_loss(C: MetricTest) -> None:
+    assert C.metric.normalized_loss(C.value) == C.expected_normalized_loss
+
+
 @parametrize_with_cases(argnames="C", cases=".", has_tag=["bounded"])
 def test_normalized_loss_for_bounded(C: MetricTest) -> None:
-    assert 0 <= C.metric.normalized_loss(C.value) >= 1
+    assert 0 <= C.metric.normalized_loss(C.value) <= 1
     assert C.metric.normalized_loss(C.metric.optimal) == 0
+    mid = (C.metric.optimal + C.metric.worst) / 2
+    assert C.metric.normalized_loss(mid) == 0.5
     assert C.metric.normalized_loss(C.metric.worst) == 1
 
 

--- a/tests/optimizers/test_metric.py
+++ b/tests/optimizers/test_metric.py
@@ -12,7 +12,7 @@ class MetricTest:
     """A test case for a metric."""
 
     metric: Metric
-    v: Metric.Value
+    value: float
     expected_loss: float
     expected_distance_from_optimal: float | None
     expected_score: float
@@ -24,7 +24,7 @@ def case_metric_score_bounded() -> MetricTest:
     metric = Metric("score_bounded", minimize=False, bounds=(0, 1))
     return MetricTest(
         metric=metric,
-        v=metric(0.3),
+        value=0.3,
         expected_loss=-0.3,
         expected_distance_from_optimal=0.7,
         expected_score=0.3,
@@ -37,7 +37,7 @@ def case_metric_score_unbounded() -> MetricTest:
     metric = Metric("score_unbounded", minimize=False)
     return MetricTest(
         metric=metric,
-        v=metric(0.3),
+        value=0.3,
         expected_loss=-0.3,
         expected_distance_from_optimal=None,
         expected_score=0.3,
@@ -50,7 +50,7 @@ def case_metric_loss_unbounded() -> MetricTest:
     metric = Metric("loss_unbounded", minimize=True)
     return MetricTest(
         metric=metric,
-        v=metric(0.8),
+        value=0.8,
         expected_loss=0.8,
         expected_distance_from_optimal=None,
         expected_score=-0.8,
@@ -63,7 +63,7 @@ def case_metric_loss_bounded() -> MetricTest:
     metric = Metric("loss_bounded", minimize=True, bounds=(-1, 1))
     return MetricTest(
         metric=metric,
-        v=metric(0.8),
+        value=0.8,
         expected_loss=0.8,
         expected_distance_from_optimal=1.8,
         expected_score=-0.8,
@@ -73,27 +73,27 @@ def case_metric_loss_bounded() -> MetricTest:
 
 @parametrize_with_cases(argnames="C", cases=".")
 def test_metrics_have_expected_outputs(C: MetricTest) -> None:
-    assert C.v.loss == C.expected_loss
-    assert C.v.distance_to_optimal == C.expected_distance_from_optimal
-    assert C.v.score == C.expected_score
+    assert C.metric.loss(C.value) == C.expected_loss
+    assert C.metric.distance_to_optimal(C.value) == C.expected_distance_from_optimal
+    assert C.metric.score(C.value) == C.expected_score
     assert str(C.metric) == C.expected_str
 
 
 @parametrize_with_cases(argnames="C", cases=".", has_tag=["maximize"])
 def test_metric_value_is_score_if_maximize(C: MetricTest) -> None:
-    assert C.v.value == C.v.score
-    assert C.v.value == -C.v.loss
+    assert C.value == C.metric.score(C.value)
+    assert C.value == -C.metric.loss(C.value)
 
 
 @parametrize_with_cases(argnames="C", cases=".", has_tag=["minimize"])
 def test_metric_value_is_loss_if_minimize(C: MetricTest) -> None:
-    assert C.v.value == C.v.loss
-    assert C.v.value == -C.v.score
+    assert C.value == C.metric.loss(C.value)
+    assert C.value == -C.metric.score(C.value)
 
 
 @parametrize_with_cases(argnames="C", cases=".")
 def test_metric_value_score_is_just_loss_inverted(C: MetricTest) -> None:
-    assert C.v.score == -C.v.loss
+    assert C.metric.score(C.value) == -C.metric.loss(C.value)
 
 
 @parametrize_with_cases(argnames="C", cases=".", has_tag=["minimize", "unbounded"])
@@ -124,13 +124,12 @@ def test_maximize_metric_worst_optimal_if_bounded(C: MetricTest) -> None:
 
 @parametrize_with_cases(argnames="C", cases=".", has_tag=["unbounded"])
 def test_distance_to_optimal_is_none_for_unbounded(C: MetricTest) -> None:
-    assert C.v.distance_to_optimal is None
+    assert C.metric.distance_to_optimal(C.value) is None
 
 
 @parametrize_with_cases(argnames="C", cases=".", has_tag=["bounded"])
 def test_distance_to_optimal_is_always_positive_for_bounded(C: MetricTest) -> None:
-    assert C.v.distance_to_optimal
-    assert C.v.distance_to_optimal >= 0
+    assert C.metric.distance_to_optimal(C.value) >= 0
 
 
 @parametrize_with_cases(argnames="C", cases=".")

--- a/tests/optimizers/test_optimizers.py
+++ b/tests/optimizers/test_optimizers.py
@@ -42,7 +42,10 @@ def target_function(trial: Trial, err: Exception | None = None) -> Trial.Report:
             return trial.fail(err)
 
         return trial.success(
-            **{metric.name: metric.optimal.value for metric in trial.metrics},
+            **{
+                metric_name: metric.optimal.value
+                for metric_name, metric in trial.metrics.items()
+            },
         )
 
 

--- a/tests/optimizers/test_optimizers.py
+++ b/tests/optimizers/test_optimizers.py
@@ -43,7 +43,7 @@ def target_function(trial: Trial, err: Exception | None = None) -> Trial.Report:
 
         return trial.success(
             **{
-                metric_name: metric.optimal.value
+                metric_name: metric.optimal
                 for metric_name, metric in trial.metrics.items()
             },
         )
@@ -115,7 +115,9 @@ def test_report_success(optimizer: Optimizer) -> None:
     assert report.status == Trial.Status.SUCCESS
     assert valid_time_interval(report.profiles["trial"].time)
     assert report.trial.info is trial.info
-    assert report.metric_values == tuple(metric.optimal for metric in optimizer.metrics)
+    assert report.values == {
+        name: metric.optimal for name, metric in optimizer.metrics.items()
+    }
 
 
 @parametrize_with_cases("optimizer", cases=".", prefix="opt_")
@@ -128,7 +130,9 @@ def test_report_failure(optimizer: Optimizer):
     assert valid_time_interval(report.profiles["trial"].time)
     assert isinstance(report.exception, ValueError)
     assert isinstance(report.traceback, str)
-    assert report.metric_values == tuple(metric.worst for metric in optimizer.metrics)
+    assert report.values == {
+        name: metric.optimal for name, metric in optimizer.metrics.items()
+    }
 
 
 @parametrize_with_cases("optimizer", cases=".", prefix="opt_")

--- a/tests/optimizers/test_optimizers.py
+++ b/tests/optimizers/test_optimizers.py
@@ -130,9 +130,7 @@ def test_report_failure(optimizer: Optimizer):
     assert valid_time_interval(report.profiles["trial"].time)
     assert isinstance(report.exception, ValueError)
     assert isinstance(report.traceback, str)
-    assert report.values == {
-        name: metric.optimal for name, metric in optimizer.metrics.items()
-    }
+    assert report.values == {}
 
 
 @parametrize_with_cases("optimizer", cases=".", prefix="opt_")

--- a/tests/pipeline/test_optimize.py
+++ b/tests/pipeline/test_optimize.py
@@ -47,7 +47,11 @@ def test_custom_callback_used(tmp_path: Path) -> None:
 def test_populates_given_history(tmp_path: Path) -> None:
     history = History()
     component = Component(object, space={"a": (0.0, 1.0)})
-    trial = Trial(name="test_trial", config={})
+    trial = Trial.create(
+        name="test_trial",
+        config={},
+        bucket=PathBucket(tmp_path) / "trial",
+    )
     report = trial.success()
     history.add(report)
 

--- a/tests/scheduling/plugins/test_pynisher_plugin.py
+++ b/tests/scheduling/plugins/test_pynisher_plugin.py
@@ -6,6 +6,7 @@ import warnings
 from collections import Counter
 from collections.abc import Iterator
 from concurrent.futures import Executor, ProcessPoolExecutor
+from pathlib import Path
 
 import pytest
 from dask.distributed import Client, LocalCluster, Worker
@@ -268,7 +269,7 @@ def test_time_limited_task_can_be_ignored_by_scheduler(scheduler: Scheduler) -> 
     assert isinstance(end_status.exception, PynisherPlugin.WallTimeoutException)
 
 
-def test_trial_gets_autodetect_memory(scheduler: Scheduler) -> None:
+def test_trial_gets_autodetect_memory(scheduler: Scheduler, tmp_path: Path) -> None:
     if not PynisherPlugin.supports("memory"):
         pytest.skip("Pynisher does not support memory limits on this system")
 
@@ -281,7 +282,7 @@ def test_trial_gets_autodetect_memory(scheduler: Scheduler) -> None:
             disable_trial_handling=False,
         ),
     )
-    trial = Trial(name="test_trial", config={})
+    trial = Trial.create(name="test_trial", config={}, bucket=tmp_path / "trial")
 
     @scheduler.on_start
     def start_task() -> None:
@@ -316,7 +317,7 @@ def test_trial_gets_autodetect_memory(scheduler: Scheduler) -> None:
     assert isinstance(reports[0].exception, PynisherPlugin.MemoryLimitException)
 
 
-def test_trial_gets_autodetect_time(scheduler: Scheduler) -> None:
+def test_trial_gets_autodetect_time(scheduler: Scheduler, tmp_path: Path) -> None:
     if not PynisherPlugin.supports("wall_time"):
         pytest.skip("Pynisher does not support wall_time limits on this system")
 
@@ -327,7 +328,7 @@ def test_trial_gets_autodetect_time(scheduler: Scheduler) -> None:
             disable_trial_handling=False,
         ),
     )
-    trial = Trial(name="test_trial", config={})
+    trial = Trial.create(name="test_trial", config={}, bucket=tmp_path / "trial")
 
     @scheduler.on_start
     def start_task() -> None:


### PR DESCRIPTION
This PR is namely just refactoring the `Metric` and where it was used to make it easier to go directly from `Metric` to `sklearn.metric._scorer._Scorer` or `_MultiScorer` in the next steps.
Notably, you can attach a `fn` to a `Metric` and call `as_sklearn_scorer(...) -> _Scorer` on it. This also applies to the new `MetricCollection(Mapping[str, Any])` where you can call `as_sklearn_scorer(...) -> _MultiMetricScorer`.

This enables the following improvement for sklearn integration:

```python
def evaluate(trial: Trial, pipeline: Node) -> Trial.Report:
    model = (
        pipeline.configure(trial.config).build("sklearn").set_output(transform="pandas")
    )
    X, y, _, _ = dataset.get_data(target=dataset.default_target_attribute)
    with trial.profile("fit"):
        model.fit(X, y)

    # Convert the metrics to an sklearn scorer
    # Works seemlessly with single or multiple metrics defined
	# Could also do `acc = trial.metrics["accuracy"].as_sklearn_scorer()`
    scorer = trial.metrics.as_sklearn_scorer()
    with trial.profile("scoring"):
        scores = scorer(model, X, y)

    return trial.success(**scores)


# Custom metric
def custom_acc(y_pred, y_true) -> float:
    return -(y_pred == y_true).mean()


# Will use `get_scorer` to get the scorer
metric = Metric("accuracy", bounds=(0, 1), minimize=False)

# Will use `make_scorer` using the information here
metric_2 = Metric("custom", bounds=(0, 1), minimize=True, fn=custom_acc)

pipeline = (
    Component(OrdinalEncoder)
    >> Component(
        RandomForestClassifier,
        space={"n_estimators": (10, 100)},
        config={"criterion": "gini"},
    )
)
history = pipeline.optimize(
    evaluate,
    max_trials=5,
    metric=[metric, metric_2],
)

print(history.df(profiles=False))
```

Feel free to skip most of the code review as it's mostly just refactoring.
There will be more work towards make this workflow as streamlined as possible!

TODO:
* Implement tests for sklearn functionality of metrics. Right now they were just manually tested.

---

While doing so, it also became more apparent that the `Trial` class is a bit too dynamic and had to much early feature scope. Part of this was also to reduce the attributes available on a `Report`, make the actual values always with the metric names as a dict and remove the `Metric.Value` class.

* Now, the preferred way to create a `Trial` one is with `create()`, although normally an optimizer will just make one for a user and it's not manually specified. This prevents them being in a slightly too dynamic of a state.
* I removed the notion of `where=` for `store()` and `retrieve()`. They will always have a `PathBucket` attached to them and we can revisit this if needed.
* The `metrics` is now a `MetricCollection(Mapping[str, Metric])`, essentially a dict where you can go `trial.metrics["accuracy"]`.
* This matches the `Report` as well with `report.metrics["accuracy"]`. You can also access the raw values reported with `report.values["accuracy"]`.
    * This removed about 2 fields extraneous fields from report which was nice.