### PR TITLE
feat(sklearn): Provide a standard CVEvaluator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ example-*
 results
 typings
 unknown-trial-bucket
+.ipynb_checkpoints

--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -324,6 +324,7 @@ use cases, you should be able to swap in and out the optimizer and it should wor
 ```python exec="true" result="python" source="material-block" session="optimizing-an-sklearn-pipeline"
 from amltk.optimization.optimizers.smac import SMACOptimizer
 from amltk.optimization import Metric, History
+from amltk.store import PathBucket
 
 metric = Metric("acc", minimize=False, bounds=(0, 1))
 bucket = PathBucket("my-bucket")

--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -304,16 +304,17 @@ multiple processes or remote compute, this is a good practice to follow.
 For this we use a [`PathBucket`][amltk.store.PathBucket] and get
 a [`Stored`][amltk.store.Stored] from it, a reference to some object we can `load()` back in later.
 
-```python
+```python exec="true" result="python" source="material-block" session="optimizing-an-sklearn-pipeline"
 from sklearn.datasets import load_iris
+from amltk.store import PathBucket
 
 # Load in our data
 _X, _y = load_iris(return_X_y=True)
 
 # Store our data in a bucket
 bucket = PathBucket("my-bucket")
-stored_x = bucket["X.npy"].put(_X)
-stored_y = bucket["X.npy"].put(_y)
+stored_X = bucket["X.npy"].put(_X)
+stored_y = bucket["y.npy"].put(_y)
 ```
 
 Lastly, we'll create our optimizer and run it.
@@ -324,10 +325,8 @@ use cases, you should be able to swap in and out the optimizer and it should wor
 ```python exec="true" result="python" source="material-block" session="optimizing-an-sklearn-pipeline"
 from amltk.optimization.optimizers.smac import SMACOptimizer
 from amltk.optimization import Metric, History
-from amltk.store import PathBucket
 
 metric = Metric("acc", minimize=False, bounds=(0, 1))
-bucket = PathBucket("my-bucket")
 optimizer = SMACOptimizer.create(
     space=my_pipeline,  # Let it know what to optimize
     metrics=metric,  # And let it know what to expect

--- a/docs/hooks/cleanup_log_output.py
+++ b/docs/hooks/cleanup_log_output.py
@@ -13,6 +13,8 @@ import mkdocs
 import mkdocs.plugins
 import mkdocs.structure.pages
 
+from amltk.exceptions import AutomaticParameterWarning, TaskTypeWarning
+
 log = logging.getLogger("mkdocs")
 
 
@@ -20,6 +22,10 @@ log = logging.getLogger("mkdocs")
 def on_startup(**kwargs: Any):
     # We get a load of deprecation warnings from SMAC
     warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    # We ignore AutoWarnings as our example tend to rely on
+    # a lot of the `"auto"` parameters
+    warnings.filterwarnings("ignore", category=AutomaticParameterWarning)
 
     # ConvergenceWarning from sklearn
     warnings.filterwarnings("ignore", module="sklearn")

--- a/docs/reference/optimization/history.md
+++ b/docs/reference/optimization/history.md
@@ -33,6 +33,7 @@ for trial in trials:
     history.add(report)
 
 print(history.df())
+for trial in trials: trial.bucket.rmdir()  # markdown-exec: hide
 ```
 
 Typically, to use this inside of an optimization run, you would add the reports inside

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ exclude = [
   "PD901",   #  X is a bad variable name. (pandas)
   "TCH",
   "N803",
+  "C901",  # Too complex
 ]
 "src/amltk/__version__.py" = ["D100"]
 "__init__.py" = ["I002"]

--- a/src/amltk/exceptions.py
+++ b/src/amltk/exceptions.py
@@ -110,3 +110,15 @@ class DuplicateNamesError(ValueError):
             f"Duplicate names found in {self.node.name} and can't be handled."
             f"\nnodes: {[n.name for n in self.node.nodes]}."
         )
+
+
+class AutomaticParameterWarning(UserWarning):
+    """Raised when automatic parameter is enabled.
+
+    Normally this means something should be explicitly set to
+    be more clear.
+    """
+
+
+class AutomaticThreadPoolCTLWarning(AutomaticParameterWarning):
+    """Raised when automatic threadpoolctl is enabled."""

--- a/src/amltk/exceptions.py
+++ b/src/amltk/exceptions.py
@@ -68,6 +68,13 @@ class IntegrationNotFoundError(Exception):
         super().__init__(f"No integration found for {name}.")
 
 
+class AutomaticParameterWarning(UserWarning):
+    """Raised when an "auto" parameter of a function is used
+    and triggers some behaviour which would be better explicitly
+    set.
+    """
+
+
 class SchedulerNotRunningError(RuntimeError):
     """The scheduler is not running."""
 
@@ -112,13 +119,30 @@ class DuplicateNamesError(ValueError):
         )
 
 
-class AutomaticParameterWarning(UserWarning):
-    """Raised when automatic parameter is enabled.
+class AutomaticThreadPoolCTLWarning(AutomaticParameterWarning):
+    """Raised when automatic threadpoolctl is enabled."""
 
-    Normally this means something should be explicitly set to
-    be more clear.
+
+class ImplicitMetricConversionWarning(UserWarning):
+    """A warning raised when a metric is implicitly converted to an sklearn scorer.
+
+    This is raised when a metric is provided with a custom function and is
+    implicitly converted to an sklearn scorer. This may fail in some cases
+    and it is recommended to explicitly convert the metric to an sklearn
+    scorer with `make_scorer` and then pass it to the metric with
+    [`Metric(fn=...)`][amltk.optimization.Metric].
     """
 
 
-class AutomaticThreadPoolCTLWarning(AutomaticParameterWarning):
-    """Raised when automatic threadpoolctl is enabled."""
+class TaskTypeWarning(UserWarning):
+    """A warning raised about the task type."""
+
+
+class AutomaticTaskTypeInferredWarning(TaskTypeWarning, AutomaticParameterWarning):
+    """A warning raised when the task type is inferred from the target data."""
+
+
+class MismatchedTaskTypeWarning(TaskTypeWarning):
+    """A warning raised when inferred task type with `task_hint` does not
+    match the inferred task type from the target data.
+    """

--- a/src/amltk/optimization/__init__.py
+++ b/src/amltk/optimization/__init__.py
@@ -1,3 +1,7 @@
+from amltk.optimization.evaluation import (
+    CustomEvaluationProtocol,
+    EvaluationProtocol,
+)
 from amltk.optimization.history import History
 from amltk.optimization.metric import Metric, MetricCollection
 from amltk.optimization.optimizer import Optimizer
@@ -9,4 +13,6 @@ __all__ = [
     "Metric",
     "MetricCollection",
     "History",
+    "EvaluationProtocol",
+    "CustomEvaluationProtocol",
 ]

--- a/src/amltk/optimization/evaluation.py
+++ b/src/amltk/optimization/evaluation.py
@@ -46,7 +46,7 @@ class EvaluationProtocol:
         return scheduler.task(self.fn, plugins=_plugins)
 
 
-class CustomProtocol(EvaluationProtocol):
+class CustomEvaluationProtocol(EvaluationProtocol):
     """A custom evaluation protocol based on a user function."""
 
     def __init__(self, fn: Callable[[Trial, Node], Trial.Report]) -> None:

--- a/src/amltk/optimization/history.py
+++ b/src/amltk/optimization/history.py
@@ -52,7 +52,7 @@ your reports and load them back in later:
     a `pd.DataFrame`.
 
 You can also retrieve individual reports from the history by using their
-name, e.g. `#!python history["some-unique-name"]` or iterate through
+name, e.g. `#!python history.reports["some-unique-name"]` or iterate through
 the history with `#!python for report in history: ...`.
 """  # noqa: E501
 from __future__ import annotations
@@ -108,6 +108,7 @@ class History(RichRenderable):
         x = trial.config["x"]
         report = trial.success(cost=x**2 - x*2 + 4)
         history.add(report)
+        trial.bucket.rmdir()  # markdown-exec: hide
 
     for report in history:
         print(f"{report.name=}, {report}")
@@ -247,6 +248,7 @@ class History(RichRenderable):
             x = trial.config["x"]
             report = trial.success(cost=x**2 - x*2 + 4)
             history.add(report)
+            trial.bucket.rmdir() # markdown-exec: hide
 
         print(history.df())
         ```
@@ -310,6 +312,7 @@ class History(RichRenderable):
         for trial in trials:
             x = trial.config["x"]
             report = trial.success(cost=x**2 - x*2 + 4)
+            trial.bucket.rmdir() # markdown-exec: hide
             history.add(report)
 
         filtered_history = history.filter(lambda report: report.values["cost"] < 10)
@@ -345,6 +348,7 @@ class History(RichRenderable):
                 report = trial.fail(cost=1_000)
             else:
                 report = trial.success(cost=x**2 - x*2 + 4)
+            trial.bucket.rmdir() # markdown-exec: hide
             history.add(report)
 
         for status, history in history.groupby("status").items():
@@ -364,6 +368,7 @@ class History(RichRenderable):
             x = trial.config["x"]
             report = trial.fail(cost=x)
             history.add(report)
+            trial.bucket.rmdir() # markdown-exec: hide
 
         for below_5, history in history.groupby(lambda r: r.values["cost"] < 5).items():
             print(f"{below_5=}, {len(history)=}")
@@ -408,6 +413,7 @@ class History(RichRenderable):
             x = trial.config["x"]
             report = trial.success(cost=x**2 - x*2 + 4)
             history.add(report)
+            trial.bucket.rmdir() # markdown-exec: hide
 
         incumbents = (
             history
@@ -473,6 +479,7 @@ class History(RichRenderable):
             x = trial.config["x"]
             report = trial.success(cost=x**2 - x*2 + 4)
             history.add(report)
+            trial.bucket.rmdir() # markdown-exec: hide
 
         trace = (
             history

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -121,6 +121,7 @@ class Trial(RichRenderable, Generic[I]):
 
         report = target_function(trial)
         print(report.df())
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
 
@@ -178,6 +179,7 @@ class Trial(RichRenderable, Generic[I]):
 
             # Correct usage
             report = trial.success(accuracy=0.95)
+            trial.bucket.rmdir()  # markdown-exec: hide
             ```
 
     If using [`Plugins`][amltk.scheduling.plugins.Plugin], they may insert
@@ -206,6 +208,7 @@ class Trial(RichRenderable, Generic[I]):
                 pass
 
         print(trial.profiler.df())
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
     You can also record anything you'd like into the
@@ -379,6 +382,7 @@ class Trial(RichRenderable, Generic[I]):
             time.sleep(1)
 
         print(trial.profiler["some_interval"].time)
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
         Args:
@@ -411,6 +415,7 @@ class Trial(RichRenderable, Generic[I]):
         report = trial.success(loss=1)
 
         print(report)
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
         Args:
@@ -473,6 +478,7 @@ class Trial(RichRenderable, Generic[I]):
 
         print(report.values)
         print(report)
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
         Returns:
@@ -548,6 +554,7 @@ class Trial(RichRenderable, Generic[I]):
         trial = Trial.create(name="trial", config={"x": 1}, bucket=PathBucket("my-trial"))
         trial.store({"config.json": trial.config})
         print(trial.storage)
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
         Args:
@@ -574,21 +581,7 @@ class Trial(RichRenderable, Generic[I]):
         trial.delete_from_storage(items=["config.json"])
 
         print(trial.storage)
-        ```
-
-        You could also create a Bucket and use that instead.
-
-        ```python exec="true" source="material-block" result="python" title="delete-storage-bucket" hl_lines="9"
-        from amltk.optimization import Trial
-        from amltk.store import PathBucket
-
-        bucket = PathBucket("results")
-        trial = Trial.create(name="trial", config={"x": 1}, bucket=bucket)
-
-        trial.store({"config.json": trial.config})
-        trial.delete_from_storage(items=["config.json"])
-
-        print(trial.storage)
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
         Args:
@@ -634,6 +627,7 @@ class Trial(RichRenderable, Generic[I]):
         config = trial.retrieve("config.json")
 
         print(config)
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
         Args:
@@ -775,6 +769,7 @@ class Trial(RichRenderable, Generic[I]):
             report = trial.success(loss=1)
 
         print(report.df())
+        trial.bucket.rmdir()  # markdown-exec: hide
         ```
 
         These reports are used to report back metrics to an
@@ -930,6 +925,7 @@ class Trial(RichRenderable, Generic[I]):
 
             config = report.retrieve("config.json")
             print(config)
+            trial.bucket.rmdir()  # markdown-exec: hide
             ```
 
             Args:

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -337,6 +337,23 @@ class Trial(RichRenderable, Generic[I]):
         """The profiles of the trial."""
         return self.profiler.profiles
 
+    def dump_exception(
+        self,
+        exception: BaseException,
+        *,
+        name: str | None = None,
+    ) -> None:
+        """Dump an exception to the trial.
+
+        Args:
+            exception: The exception to dump.
+            name: The name of the file to dump to. If `None`, will be `"exception"`.
+        """
+        fname = name if name is not None else "exception"
+        traceback = "".join(traceback_module.format_tb(exception.__traceback__))
+        msg = f"{traceback}\n{exception.__class__.__name__}: {exception}"
+        self.store({f"{fname}.txt": msg})
+
     @contextmanager
     def profile(
         self,

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -67,7 +67,7 @@ from sklearn.pipeline import Pipeline as SklearnPipeline
 
 from amltk._functional import classname, funcname, mapping_select, prefix_keys
 from amltk._richutil import RichRenderable
-from amltk.exceptions import RequestNotMetError
+from amltk.exceptions import AutomaticThreadPoolCTLWarning, RequestNotMetError
 from amltk.optimization.history import History
 from amltk.optimization.optimizer import Optimizer
 from amltk.scheduling import Task
@@ -1110,6 +1110,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                         " the CPU and cause the system to slow down."
                         "\nPlease set `threadpool_limit_ctl=False` if you do not want"
                         " this behaviour and set it to `True` to silence this warning.",
+                        AutomaticThreadPoolCTLWarning,
                         stacklevel=2,
                     )
             case True:

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -1139,7 +1139,7 @@ class Node(RichRenderable, Generic[Item, Space]):
             case _:
                 raise ValueError(f"{max_trials=} must be a positive int")
 
-        from amltk.evalutors.evaluation_protocol import EvaluationProtocol
+        from amltk.optimization.evaluation import EvaluationProtocol
 
         match target:
             case EvaluationProtocol():
@@ -1150,9 +1150,9 @@ class Node(RichRenderable, Generic[Item, Space]):
                     "Not sure how to handle an already created task yet",
                 )
             case _ if callable(target):
-                from amltk.evalutors.evaluation_protocol import CustomProtocol
+                from amltk.optimization.evaluation import CustomEvaluationProtocol
 
-                target = CustomProtocol(target)
+                target = CustomEvaluationProtocol(target)
             case _:
                 raise ValueError(
                     f"Invalid target {target}. Must be a function or an"

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -82,7 +82,7 @@ if TYPE_CHECKING:
     from rich.console import RenderableType
     from rich.panel import Panel
 
-    from amltk.evalutors.evaluation_protocol import EvaluationProtocol
+    from amltk.optimization.evaluation import EvaluationProtocol
     from amltk.optimization.metric import Metric
     from amltk.optimization.trial import Trial
     from amltk.pipeline.components import Choice, Join, Sequential
@@ -911,7 +911,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                 The function against which to optimize.
 
                 * If `target` is an
-                [`EvaluationProtocol`][amltk.evalutors.evaluation_protocol.EvaluationProtocol],
+                [`EvaluationProtocol`][amltk.optimization.evaluation.EvaluationProtocol],
                 then it will be used to evaluate the pipeline.
 
                 * If `target` is a function, then it must take in a
@@ -1310,7 +1310,7 @@ class Node(RichRenderable, Generic[Item, Space]):
                 The function against which to optimize.
 
                 * If `target` is an
-                [`EvaluationProtocol`][amltk.evalutors.evaluation_protocol.EvaluationProtocol],
+                [`EvaluationProtocol`][amltk.optimization.evaluation.EvaluationProtocol],
                 then it will be used to evaluate the pipeline.
 
                 * If `target` is a function, then it must take in a

--- a/src/amltk/profiling/profiler.py
+++ b/src/amltk/profiling/profiler.py
@@ -252,7 +252,7 @@ class Profiler(Mapping[str, Profile.Interval]):
         itr: Iterable[T],
         *,
         name: str,
-        itr_name: Callable[[int, T], str] | None = None,
+        itr_name: str | Callable[[int, T], str] | None = None,
     ) -> Iterator[T]:
         """Profile each item in an iterable.
 
@@ -267,11 +267,17 @@ class Profiler(Mapping[str, Profile.Interval]):
         Yields:
             The the items
         """
-        if itr_name is None:
-            itr_name = lambda i, _: str(i)
+        match itr_name:
+            case None:
+                _itr_name = lambda i, _: str(i)
+            case str():
+                _itr_name = lambda i, _: f"{itr_name}_{i}"
+            case _:
+                _itr_name = itr_name
+
         with self.measure(name=name):
             for i, item in enumerate(itr):
-                with self.measure(name=itr_name(i, item)):
+                with self.measure(name=_itr_name(i, item)):
                     yield item
 
     @contextmanager

--- a/src/amltk/sklearn/__init__.py
+++ b/src/amltk/sklearn/__init__.py
@@ -3,6 +3,7 @@ from amltk.sklearn.estimators import (
     StoredPredictionClassifier,
     StoredPredictionRegressor,
 )
+from amltk.sklearn.evaluation import CVEvaluation
 from amltk.sklearn.voting import voting_with_preffited_estimators
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "StoredPredictionRegressor",
     "StoredPredictionClassifier",
     "voting_with_preffited_estimators",
+    "CVEvaluation",
 ]

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -45,6 +45,11 @@ from sklearn.utils.validation import _check_method_params
 
 import amltk.randomness
 from amltk._functional import subclass_map
+from amltk.exceptions import (
+    AutomaticTaskTypeInferredWarning,
+    ImplicitMetricConversionWarning,
+    MismatchedTaskTypeWarning,
+)
 from amltk.optimization.evaluation import EvaluationProtocol
 from amltk.profiling.profiler import Profiler
 from amltk.store import Stored
@@ -82,31 +87,6 @@ _valid_task_types: tuple[TaskTypeName, ...] = (
     "continuous",
     "continuous-multioutput",
 )
-
-
-class ImplicitMetricConversionWarning(UserWarning):
-    """A warning raised when a metric is implicitly converted to an sklearn scorer.
-
-    This is raised when a metric is provided with a custom function and is
-    implicitly converted to an sklearn scorer. This may fail in some cases
-    and it is recommended to explicitly convert the metric to an sklearn
-    scorer with `make_scorer` and then pass it to the metric with
-    [`Metric(fn=...)`][amltk.optimization.Metric].
-    """
-
-
-class TaskTypeWarning(UserWarning):
-    """A warning raised about the task type."""
-
-
-class AutomaticTaskTypeInferredWarning(TaskTypeWarning):
-    """A warning raised when the task type is inferred from the target data."""
-
-
-class MismatchedTaskTypeWarning(TaskTypeWarning):
-    """A warning raised when inferred task type with `task_hint` does not
-    match the inferred task type from the target data.
-    """
 
 
 def _route_params(

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -618,12 +618,15 @@ class CVEvaluation(EvaluationProtocol):
     from amltk.optimization import Metric
     from sklearn.ensemble import RandomForestClassifier
     from sklearn.metrics import get_scorer
+    from sklearn.datasets import load_iris
 
     pipeline = Component(
         RandomForestClassifier,
         config={"random_state": request("random_state")},
         space={"n_estimators": (10, 100), "critera": ["gini", "entropy"]},
     )
+
+    X, y = load_iris(return_X_y=True)
     evaluator = CVEvaluation(
         X,
         y,

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -565,7 +565,7 @@ class CVEvaluation(EvaluationProtocol):
         *,
         cv: int | float | BaseShuffleSplit | BaseCrossValidator,
         train_score: bool = False,
-        store_models: bool = True,
+        store_models: bool = False,
         additional_scorers: Mapping[str, _Scorer] | None = None,
         random_state: Seed | None = None,  # Only used if cv is an int/float
         params: Mapping[str, Any] | None = None,

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -15,6 +15,7 @@ import tempfile
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sized
+from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeAlias, TypeVar
@@ -641,7 +642,7 @@ class CVEvaluation(EvaluationProtocol):
         y,
         n_splits=3,
         strategy="cv",
-        additional_scorers={"f1": get_scorer("f1")},
+        additional_scorers={"roc_auc": get_scorer("roc_auc_ovr")},
         store_models=False,
         train_score=True,
     )
@@ -809,8 +810,13 @@ class CVEvaluation(EvaluationProtocol):
         super().__init__()
         match datadir:
             case None:
-                tmpdir = tempfile.TemporaryDirectory(prefix=self.TMP_DIR_PREFIX)
-                databucket = PathBucket(tmpdir.name)
+                tmpdir = Path(
+                    tempfile.mkdtemp(
+                        prefix=self.TMP_DIR_PREFIX,
+                        suffix=datetime.now().isoformat(),
+                    ),
+                )
+                databucket = PathBucket(tmpdir)
             case str() | Path():
                 databucket = PathBucket(datadir)
             case PathBucket():

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -1,0 +1,600 @@
+"""TODO upon review."""
+from __future__ import annotations
+
+import logging
+import tempfile
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sized
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeAlias, TypeVar
+from typing_extensions import override
+
+import numpy as np
+import pandas as pd
+from sklearn import clone
+from sklearn.base import BaseEstimator
+from sklearn.exceptions import UnsetMetadataPassedError
+from sklearn.metrics import get_scorer
+from sklearn.metrics._scorer import _MultimetricScorer, _Scorer
+from sklearn.model_selection import (
+    KFold,
+    ShuffleSplit,
+    StratifiedKFold,
+    StratifiedShuffleSplit,
+)
+from sklearn.model_selection._validation import _score
+from sklearn.utils.metadata_routing import (
+    MetadataRouter,
+    MethodMapping,
+    process_routing,
+)
+from sklearn.utils.metaestimators import _safe_split
+from sklearn.utils.multiclass import type_of_target
+from sklearn.utils.validation import _check_method_params
+
+import amltk.randomness
+from amltk._functional import subclass_map
+from amltk.optimization.evaluation import EvaluationProtocol
+from amltk.profiling.profiler import Profiler
+from amltk.store import Stored
+from amltk.store.paths.path_bucket import PathBucket
+
+if TYPE_CHECKING:
+    from sklearn.model_selection import (
+        BaseCrossValidator,
+        BaseShuffleSplit,
+    )
+    from sklearn.utils import Bunch
+
+    from amltk.optimization import Trial
+    from amltk.pipeline import Node
+    from amltk.randomness import Seed
+    from amltk.scheduling import Plugin, Scheduler, Task
+
+
+logger = logging.getLogger(__name__)
+
+BaseEstimatorT = TypeVar("BaseEstimatorT", bound=BaseEstimator)
+TaskTypeName: TypeAlias = Literal[
+    "binary",
+    "multiclass",
+    "multilabel-indicator",
+    "continuous",
+    "continuous-multioutput",
+    "multiclass-multioutput",
+]
+
+
+def _route_params(
+    splitter: BaseShuffleSplit | BaseCrossValidator,
+    estimator: BaseEstimator,
+    _scorer: _Scorer | _MultimetricScorer,
+    **params: Any,
+) -> Bunch:
+    # NOTE: This is basically copied out of sklearns 1.4 cross_validate
+
+    # For estimators, a MetadataRouter is created in get_metadata_routing
+    # methods. For these router methods, we create the router to use
+    # `process_routing` on it.
+    router = (
+        MetadataRouter(owner="cross_validate")
+        .add(
+            splitter=splitter,
+            method_mapping=MethodMapping().add(caller="fit", callee="split"),
+        )
+        .add(
+            estimator=estimator,
+            # TODO(SLEP6): also pass metadata to the predict method for
+            # scoring?
+            # ^ Taken from cross_validate source code in sklearn
+            method_mapping=MethodMapping().add(caller="fit", callee="fit"),
+        )
+        .add(
+            scorer=_scorer,
+            method_mapping=MethodMapping().add(caller="fit", callee="score"),
+        )
+    )
+    try:
+        return process_routing(router, "fit", **params)  # type: ignore
+    except UnsetMetadataPassedError as e:
+        # The default exception would mention `fit` since in the above
+        # `process_routing` code, we pass `fit` as the caller. However,
+        # the user is not calling `fit` directly, so we change the message
+        # to make it more suitable for this case.
+        raise UnsetMetadataPassedError(
+            message=(
+                f"{sorted(e.unrequested_params.keys())} are passed to cross"
+                " validation but are not explicitly requested or unrequested. See"
+                " the Metadata Routing User guide"
+                " <https://scikit-learn.org/stable/metadata_routing.html> for more"
+                " information."
+            ),
+            unrequested_params=e.unrequested_params,
+            routed_params=e.routed_params,
+        ) from e
+
+
+def _default_resampler(
+    task_type: TaskTypeName,
+    *,
+    n_splits: int,
+    random_state: Seed | None = None,
+    train_size: float = 0.67,
+) -> BaseShuffleSplit | BaseCrossValidator:
+    if n_splits < 1:
+        raise ValueError("Must have at least one split")
+
+    is_holdout = n_splits == 1
+    random_state = amltk.randomness.as_int(random_state)
+
+    # TODO: Custom splitter for edge case where we only have one label
+    # For a given class
+    # if "The least populated class in y has only" in e.args[0]:
+    # Required for both of them here
+    match task_type:
+        case "binary" | "multiclass":
+            if is_holdout:
+                return StratifiedShuffleSplit(
+                    n_splits=1,
+                    random_state=random_state,
+                    train_size=train_size,
+                )
+            return StratifiedKFold(
+                n_splits=n_splits,
+                shuffle=True,
+                random_state=random_state,
+            )
+        # NOTE: They don't natively support multilabel-indicator for stratified
+        case "multilabel-indicator" | "multiclass-multioutput":
+            if is_holdout:
+                return ShuffleSplit(
+                    n_splits=1,
+                    random_state=random_state,
+                    train_size=train_size,
+                )
+
+            return KFold(n_splits=n_splits, shuffle=True, random_state=random_state)
+        case "continuous" | "continuous-multioutput":
+            if is_holdout:
+                return ShuffleSplit(
+                    n_splits=1,
+                    random_state=random_state,
+                    train_size=train_size,
+                )
+
+            return KFold(n_splits=n_splits, shuffle=True, random_state=random_state)
+
+        case _:
+            raise ValueError(f"Don't know how to handle {task_type=} with {n_splits=}")
+
+
+def identify_task_type(  # noqa: PLR0911
+    y: np.ndarray | pd.Series | pd.DataFrame,
+    *,
+    is_classification: bool | None = None,
+) -> TaskTypeName:
+    """Identify the task type from the target data."""
+    sklearn_target_type = type_of_target(y)
+    match is_classification:
+        case None:
+            return sklearn_target_type
+        case True:
+            match sklearn_target_type:
+                case "continuous":
+                    unique_values = np.unique(y)
+                    if len(unique_values) == 2:  # noqa: PLR2004
+                        return "binary"
+                    return "multiclass"
+                case "continuous-multioutput":
+                    return "multiclass-multioutput"
+                case _:
+                    return sklearn_target_type
+        case False:
+            match sklearn_target_type:
+                case "binary" | "multiclass":
+                    return "continuous"
+                case "multiclass-multioutput" | "multilabel-indicator":
+                    return "continuous-multioutput"
+                case _:
+                    return sklearn_target_type
+
+
+def _iter_cross_validate(
+    estimator: BaseEstimatorT,
+    X: pd.DataFrame | np.ndarray,  # noqa: N803
+    y: pd.Series | pd.DataFrame | np.ndarray,
+    splitter: BaseShuffleSplit | BaseCrossValidator,
+    scorers: Mapping[str, _Scorer],
+    *,
+    params: Mapping[str, Any] | None = None,
+    profiler: Profiler | None = None,
+    train_score: bool = False,
+) -> Iterator[tuple[BaseEstimatorT, Mapping[str, float], Mapping[str, float] | None]]:
+    # NOTE: This is adapted from sklearns 1.4 cross_validate
+
+    profiler = Profiler(disabled=True) if profiler is None else profiler
+    _scorer = _MultimetricScorer(scorers=scorers, raise_exc=True)
+
+    params = {} if params is None else params
+    routed_params = _route_params(splitter, estimator, _scorer, **params)
+    fit_params = routed_params["estimator"]["fit"]
+    scorer_params = routed_params["scorer"]["score"]
+
+    # Notably, this is an iterator
+    indicies = splitter.split(X, y, **routed_params["splitter"]["split"])
+
+    fit_params = fit_params if fit_params is not None else {}
+    scorer_params = scorer_params if scorer_params is not None else {}
+
+    for i_train, i_test in indicies:
+        # These return new dictionaries
+        _fit_params = _check_method_params(X, params=fit_params, indices=i_train)
+        _scorer_params_train = _check_method_params(X, scorer_params, indices=i_train)
+        _scorer_params_test = _check_method_params(X, scorer_params, indices=i_test)
+
+        X_train, y_train = _safe_split(estimator, X, y, indices=i_train)
+
+        with profiler("fit"):
+            new_estimator: BaseEstimatorT
+            new_estimator = clone(estimator)  # type: ignore
+            if y_train is None:
+                new_estimator.fit(X_train, **_fit_params)  # type: ignore
+            else:
+                new_estimator.fit(X_train, y_train, **_fit_params)  # type: ignore
+
+        X_t, y_t = _safe_split(estimator, X, y, indices=i_test, train_indices=i_train)
+
+        with profiler("score"):
+            scores = _score(
+                estimator=new_estimator,
+                X_test=X_t,
+                y_test=y_t,
+                scorer=scorers,
+                score_params=_scorer_params_test,
+                error_score="raise",
+            )
+            assert isinstance(scores, dict)
+
+        if train_score is True:
+            train_scores = _score(
+                estimator=new_estimator,
+                X_test=X_train,
+                y_test=y_train,
+                scorer=scorers,
+                score_params=_scorer_params_train,
+                error_score="raise",
+            )
+            assert isinstance(train_scores, dict)
+        else:
+            train_scores = {}
+
+        yield new_estimator, scores, train_scores
+
+
+def cross_validate_task(  # noqa: D103, PLR0913, C901, PLR0912
+    trial: Trial,
+    pipeline: Node,
+    *,
+    X: Stored[np.ndarray | pd.DataFrame],  # noqa: N803
+    y: Stored[np.ndarray | pd.Series | pd.DataFrame],
+    splitter: BaseShuffleSplit | BaseCrossValidator,
+    additional_scorers: Mapping[str, _Scorer] | None,
+    train_score: bool = False,
+    store_models: bool = True,
+    params: Mapping[str, Stored[Any] | Any] | None = None,
+    builder: Literal["sklearn"] | Callable[[Node], BaseEstimator] = "sklearn",
+    build_params: Mapping[str, Any] | None = None,
+) -> Trial.Report:
+    params = {} if params is None else params
+    # Make sure to load all the stored values
+
+    loaded_params: dict[str, Any] = {
+        k: v.load() if isinstance(v, Stored) else v for k, v in params.items()
+    }
+    build_params = {} if build_params is None else build_params
+    # TODO: Could possibly include `transform_context` here
+    estimator = (
+        pipeline.configure(trial.config, params={"random_state": trial.seed})
+        .build(builder, **build_params)
+        # TODO: Hook to allow user to do this?
+        .set_output(transform="pandas")  # type: ignore
+    )
+
+    scorers: dict[str, _Scorer] = {}
+    for metric_name, metric in trial.metrics.items():
+        match metric.fn:
+            case None:
+                try:
+                    scorer = get_scorer(metric_name)
+                    scorers[metric_name] = scorer
+                except ValueError as e:
+                    raise ValueError(
+                        f"Could not find scorer for {metric_name=} in sklearn."
+                        " Please provide one with `Metric(fn=...)` or a valid"
+                        " name that can be used with sklearn's `get_scorer`",
+                    ) from e
+            case _Scorer():  # type: ignore
+                scorers[metric_name] = metric
+            case _:
+                raise ValueError(
+                    "Cannot use a metric with a function that is not a"
+                    " `sklearn.metrics._Scorer`.",
+                )
+
+    if additional_scorers is not None:
+        scorers.update(additional_scorers)
+
+    cv_iter = _iter_cross_validate(
+        estimator=estimator,
+        X=X.load(),
+        y=y.load(),
+        splitter=splitter,
+        scorers=scorers,
+        params=loaded_params,
+        profiler=trial.profiler,
+        train_score=train_score,
+    )
+    all_train_scores: dict[str, list[float]] = defaultdict(list)
+    all_val_scores: dict[str, list[float]] = defaultdict(list)
+
+    try:
+        # Main cv loop
+        for i, (_trained_estimator, _val_scores, _train_scores) in trial.profiler.each(
+            enumerate(cv_iter),
+            name="cv",
+            itr_name="fold",
+        ):
+            if store_models:
+                trial.store({f"model_{i}.pkl": _trained_estimator})
+
+            trial.summary.update({f"fold_{i}:{k}": v for k, v in _val_scores.items()})
+            for k, v in _val_scores.items():
+                all_val_scores[k].append(v)
+
+            if _train_scores is not None:
+                trial.summary.update(
+                    {f"fold_{i}:train_{k}": v for k, v in _train_scores.items()},
+                )
+                for k, v in _train_scores.items():
+                    all_train_scores[k].append(v)
+
+    except Exception as e:  # noqa: BLE001
+        trial.dump_exception(e)
+        return trial.fail(e)
+    else:
+        mean_val_scores = {k: np.mean(v) for k, v in all_val_scores.items()}
+        std_val_scores = {k: np.std(v) for k, v in all_val_scores.items()}
+        trial.summary.update({f"mean_{k}": v for k, v in mean_val_scores.items()})
+        trial.summary.update({f"std_{k}": v for k, v in std_val_scores.items()})
+
+        if any(all_train_scores):
+            mean_train_scores = {k: np.mean(v) for k, v in all_train_scores.items()}
+            std_train_scores = {k: np.std(v) for k, v in all_train_scores.items()}
+            trial.summary.update(
+                {f"train_mean_{k}": v for k, v in mean_train_scores.items()},
+            )
+            trial.summary.update(
+                {f"train_std_{k}": v for k, v in std_train_scores.items()},
+            )
+
+        metrics_to_report = {
+            k: float(v) for k, v in mean_val_scores.items() if k in trial.metrics
+        }
+        return trial.success(**metrics_to_report)
+
+
+class CVEvaluation(EvaluationProtocol):
+    """Cross-validation evaluation protocol."""
+
+    TMP_DIR_PREFIX: ClassVar[str] = "amltk-sklearn-cv-evaluation-data-"
+    """Prefix for temporary directory names.
+
+    This is only used when `datadir` is not specified. If not specified
+    you can control the tmp dir location by setting the `TMPDIR`
+    environment variable. By default this is `/tmp`.
+
+    When using a temporary directory, it will be deleted by default,
+    controlled by the `delete_datadir=` argument.
+    """
+
+    _X_FILENAME: ClassVar[str] = "X.pkl"
+    """The name of the file to store the features in."""
+
+    _Y_FILENAME: ClassVar[str] = "y.pkl"
+    """The name of the file to store the target in."""
+
+    _PARAM_EXTENSION_MAPPING: ClassVar[dict[type[Sized], str]] = {
+        np.ndarray: "npy",
+        pd.DataFrame: "pdpickle",
+        pd.Series: "pdpickle",
+    }
+    """The mapping from types to extensions in
+    [`params`][amltk.sklearn.evaluation.CVEvaluation.params].
+
+    If the parameter is an instance of one of these types, and is larger than
+    [`LARGE_PARAM_HEURISTIC`][amltk.sklearn.evaluation.CVEvaluation.LARGE_PARAM_HEURISTIC],
+    then it will be stored to disk and loaded back up in the task.
+    """
+
+    LARGE_PARAM_HEURISTIC: ClassVar[int] = 100
+    """The number of parameters that is considered large and will be stored to disk.
+
+    When launching tasks, pickling and streaming large data to tasks can be expensive.
+    This parameter checks if the object is large and if so, stores it to disk and
+    gives it to the task as a [`Stored`][amltk.store.stored.Stored] object instead
+    """
+
+    task_type: TaskTypeName
+    """The inferred task type."""
+
+    additional_scorers: Mapping[str, _Scorer] | None
+    """Additional scorers that will be used."""
+
+    databucket: PathBucket
+    """The bucket to use for storing data.
+
+    For cleanup, you can call
+    [`databucket.rmdir()`][amltk.store.paths.path_bucket.PathBucket.rmdir].
+    """
+
+    splitter: BaseShuffleSplit | BaseCrossValidator
+    """The splitter that will be used."""
+
+    params: Mapping[str, Any | Stored[Any]]
+    """Parameters to pass to the estimator, splitter or scorers.
+
+    Please see https://scikit-learn.org/stable/metadata_routing.html for
+    more.
+    """
+
+    store_models: bool
+    """Whether models will be stored in the trial."""
+
+    train_score: bool
+    """Whether scores will be calculated on the training data as well."""
+
+    X_stored: Stored[np.ndarray | pd.DataFrame]
+    """The stored features.
+
+    You can call [`.load()`][amltk.store.stored.Stored.load] to load the
+    data.
+    """
+
+    y_stored: Stored[np.ndarray | pd.Series | pd.DataFrame]
+    """The stored target.
+
+    You can call [`.load()`][amltk.store.stored.Stored.load] to load the
+    data.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        X: pd.DataFrame | np.ndarray,  # noqa: N803
+        y: pd.Series | pd.DataFrame | np.ndarray,
+        *,
+        cv: int | float | BaseShuffleSplit | BaseCrossValidator,
+        train_score: bool = False,
+        store_models: bool = True,
+        additional_scorers: Mapping[str, _Scorer] | None = None,
+        random_state: Seed | None = None,  # Only used if cv is an int/float
+        params: Mapping[str, Any] | None = None,
+        is_classification: bool | None = None,
+        datadir: str | Path | PathBucket | None = None,
+    ) -> None:
+        """Initialize the evaluation protocol.
+
+        Args:
+            X: The features to use for training.
+            y: The target to use for training.
+            cv: The cross-validation strategy to use. This can be either an
+                integer, a float, or a scikit-learn cross-validator.
+                If an integer is provided, it will be used as the number of
+                folds to use. If a float is provided, it will be used as the
+                train size in a train/test split.
+                If a scikit-learn cross-validator is provided, this will be
+                used directly.
+            train_score: Whether to score on the training data as well. This
+                will take extra time as predictions will be made on the
+                training data as well.
+            store_models: Whether to store the trained models in the trial.
+            additional_scorers: Additional scorers to use.
+            random_state: The random state to use for the cross-validation
+                strategy. This is only used if `cv` is an integer or a float.
+            params: Parameters to pass to the estimator, splitter or scorers.
+                See https://scikit-learn.org/stable/metadata_routing.html for
+                more information.
+            is_classification: Whether the task is a classification task.
+                If not provided, this will be inferred from the target data.
+                If you know this value, it is recommended to provide it as
+                sometimes the target is ambiguous and sklearn may infer
+                incorrectly.
+            datadir: The directory to use for storing data. If not provided,
+                a temporary directory will be used. If provided as a string
+                or a `Path`, it will be used as the path to the directory.
+        """
+        super().__init__()
+        match datadir:
+            case None:
+                tmpdir = tempfile.TemporaryDirectory(prefix=self.TMP_DIR_PREFIX)
+                databucket = PathBucket(tmpdir.name)
+            case str() | Path():
+                databucket = PathBucket(datadir)
+            case PathBucket():
+                databucket = datadir
+
+        task_type = identify_task_type(y, is_classification=is_classification)
+        match cv:
+            case int():
+                if cv <= 1:
+                    raise ValueError("cv must be > 1 if provided as an int")
+                cv = _default_resampler(
+                    task_type,
+                    n_splits=cv,
+                    random_state=random_state,
+                )
+            case float():
+                if not 0 < cv < 1:
+                    raise ValueError("cv must be > 0 and < 1 if provided as a float")
+                cv = _default_resampler(
+                    task_type,
+                    n_splits=1,
+                    random_state=random_state,
+                    train_size=cv,
+                )
+            case _:
+                pass
+
+        self.task_type = task_type
+        self.additional_scorers = additional_scorers
+        self.databucket = databucket
+        self.is_classification = is_classification
+        self.splitter = cv
+        self.params = dict(params) if params is not None else {}
+        self.store_models = store_models
+        self.train_score = train_score
+
+        self.X_stored = self.databucket[self._X_FILENAME].put(X)
+        self.y_stored = self.databucket[self._Y_FILENAME].put(y)
+
+        # We apply a heuristic that "large" parameters, such as sample_weights
+        # should be stored to disk as transfering them directly to subprocess as
+        # parameters is quite expensive (they must be non-optimally pickled and
+        # streamed to the recieving process). By saving it to a file, we can
+        # make use of things like numpy/pandas specific efficient pickling
+        # protocols and also avoid the need to stream it to the subprocess.
+        storable_params = {
+            k: v
+            for k, v in self.params.items()
+            if hasattr(v, "__len__") and len(v) > self.LARGE_PARAM_HEURISTIC  # type: ignore
+        }
+        for k, v in storable_params.items():
+            match subclass_map(v, self._PARAM_EXTENSION_MAPPING, default=None):  # type: ignore
+                case (_, extension_to_save_as):
+                    ext = extension_to_save_as
+                case _:
+                    ext = "pkl"
+
+            self.params[k] = self.databucket[f"{k}.{ext}"].put(v)
+
+        # This is the actual function that will be called in the task
+        self.fn = partial(
+            cross_validate_task,
+            X=self.X_stored,
+            y=self.y_stored,
+            splitter=self.splitter,
+            additional_scorers=self.additional_scorers,
+            params=self.params,
+            store_models=self.store_models,
+            train_score=self.train_score,
+            builder="sklearn",  # TODO: Allow user to specify? e.g. custom builder
+            build_params=None,  # TODO: Allow user to specify? e.g. Imblearn pipeline
+        )
+
+    @override
+    def task(
+        self,
+        scheduler: Scheduler,
+        plugins: Plugin | Iterable[Plugin] | None = None,
+    ) -> Task[[Trial, Node], Trial.Report]:
+        return scheduler.task(self.fn, plugins=plugins if plugins is not None else ())

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -99,7 +99,7 @@ class TaskTypeWarning(UserWarning):
     """A warning raised about the task type."""
 
 
-class NoProvidedIsClassificationWarning(TaskTypeWarning):
+class AutomaticTaskTypeInferredWarning(TaskTypeWarning):
     """A warning raised when the task type is inferred from the target data."""
 
 
@@ -214,7 +214,7 @@ def identify_task_type(  # noqa: PLR0911
             "`task_hint` was not provided. The task type was inferred from"
             f" the target data to be '{inferred_type}'."
             " To silence this warning, please provide `task_hint`.",
-            NoProvidedIsClassificationWarning,
+            AutomaticTaskTypeInferredWarning,
             stacklevel=2,
         )
         return inferred_type

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -333,10 +333,12 @@ def cross_validate_task(  # noqa: D103, PLR0913, C901, PLR0912
         k: v.load() if isinstance(v, Stored) else v for k, v in params.items()
     }
     build_params = {} if build_params is None else build_params
-    # TODO: Could possibly include `transform_context` here
+    random_state = amltk.randomness.as_randomstate(trial.seed)
+
+    # TODO: Could possibly include `transform_context` here to `configure()`
     estimator = pipeline.configure(
         trial.config,
-        params={"random_state": trial.seed},
+        params={"random_state": random_state},
     ).build(builder, **build_params)
 
     scorers: dict[str, _Scorer] = {}

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -1,4 +1,13 @@
-"""TODO upon review."""
+"""This module contains the cross-validation evaluation protocol.
+
+This protocol will create a cross-validation task to be used in parallel and
+optimization. It represents a typical cross-validation evaluation for sklearn,
+handling some of the minor nuances of sklearn and it's interaction with
+optimization and parallelization.
+
+Please see [`CVEvaluation`][amltk.sklearn.evaluation.CVEvaluation] for more
+information on usage.
+"""
 from __future__ import annotations
 
 import logging
@@ -630,7 +639,8 @@ class CVEvaluation(EvaluationProtocol):
     evaluator = CVEvaluation(
         X,
         y,
-        cv=3,
+        n_splits=3,
+        strategy="cv",
         additional_scorers={"f1": get_scorer("f1")},
         store_models=False,
         train_score=True,

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -294,7 +294,15 @@ def _iter_cross_validate(
                 score_params=_scorer_params_test,
                 error_score="raise",
             )
+            # NOTE: Despite `error_score="raise"`, this will not raise
+            # for `inf` or `nan` values.
             assert isinstance(scores, dict)
+            for k, v in scores.items():
+                if np.isfinite(v) is not True:  # Can return list, check explicitly True
+                    raise ValueError(
+                        f"Scorer {k} returned {v} for validation fold. The scorer"
+                        " should return a finite float",
+                    )
 
         if train_score is True:
             train_scores = _score(
@@ -306,6 +314,12 @@ def _iter_cross_validate(
                 error_score="raise",
             )
             assert isinstance(train_scores, dict)
+            for k, v in train_scores.items():
+                if np.isfinite(v) is not True:  # Can return list, check explicitly True
+                    raise ValueError(
+                        f"Scorer {k} returned {v} for train fold. The scorer should"
+                        " should return a finite float",
+                    )
         else:
             train_scores = {}
 

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -334,12 +334,10 @@ def cross_validate_task(  # noqa: D103, PLR0913, C901, PLR0912
     }
     build_params = {} if build_params is None else build_params
     # TODO: Could possibly include `transform_context` here
-    estimator = (
-        pipeline.configure(trial.config, params={"random_state": trial.seed})
-        .build(builder, **build_params)
-        # TODO: Hook to allow user to do this?
-        .set_output(transform="pandas")  # type: ignore
-    )
+    estimator = pipeline.configure(
+        trial.config,
+        params={"random_state": trial.seed},
+    ).build(builder, **build_params)
 
     scorers: dict[str, _Scorer] = {}
     for metric_name, metric in trial.metrics.items():

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -632,7 +632,7 @@ class CVEvaluation(EvaluationProtocol):
     pipeline = Component(
         RandomForestClassifier,
         config={"random_state": request("random_state")},
-        space={"n_estimators": (10, 100), "critera": ["gini", "entropy"]},
+        space={"n_estimators": (10, 100), "criterion": ["gini", "entropy"]},
     )
 
     X, y = load_iris(return_X_y=True)
@@ -648,7 +648,7 @@ class CVEvaluation(EvaluationProtocol):
 
     history = pipeline.optimize(
         target=evaluator,
-        metrics=Metric("accuracy", minimize=False, bounds=(0, 1)),
+        metric=Metric("accuracy", minimize=False, bounds=(0, 1)),
         n_workers=4,
     )
     print(history.df())

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -648,9 +648,9 @@ class CVEvaluation(EvaluationProtocol):
         self.y_stored = self.databucket[self._Y_FILENAME].put(y)
 
         # We apply a heuristic that "large" parameters, such as sample_weights
-        # should be stored to disk as transfering them directly to subprocess as
+        # should be stored to disk as transferring them directly to subprocess as
         # parameters is quite expensive (they must be non-optimally pickled and
-        # streamed to the recieving process). By saving it to a file, we can
+        # streamed to the receiving process). By saving it to a file, we can
         # make use of things like numpy/pandas specific efficient pickling
         # protocols and also avoid the need to stream it to the subprocess.
         storable_params = {

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -650,7 +650,6 @@ class CVEvaluation(EvaluationProtocol):
     history = pipeline.optimize(
         target=evaluator,
         metric=Metric("accuracy", minimize=False, bounds=(0, 1)),
-        n_workers=4,
     )
     print(history.df())
     ```

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -185,13 +185,13 @@ def _default_cv_resampler(
 def identify_task_type(  # noqa: PLR0911
     y: np.ndarray | pd.Series | pd.DataFrame,
     *,
-    task_hint: Literal["classification", "regression"] | None = None,
+    task_hint: Literal["classification", "regression", "auto"] = "auto",
 ) -> TaskTypeName:
     """Identify the task type from the target data."""
     inferred_type: TaskTypeName = type_of_target(y)
-    if task_hint is None:
+    if task_hint == "auto":
         warnings.warn(
-            "`task_hint` was not provided. The task type was inferred from"
+            f"`{task_hint=}` was not provided. The task type was inferred from"
             f" the target data to be '{inferred_type}'."
             " To silence this warning, please provide `task_hint`.",
             AutomaticTaskTypeInferredWarning,
@@ -737,7 +737,9 @@ class CVEvaluation(EvaluationProtocol):
         additional_scorers: Mapping[str, _Scorer] | None = None,
         random_state: Seed | None = None,  # Only used if cv is an int/float
         params: Mapping[str, Any] | None = None,
-        task_hint: TaskTypeName | Literal["classification", "regression"] | None = None,
+        task_hint: (
+            TaskTypeName | Literal["classification", "regression", "auto"]
+        ) = "auto",
         working_dir: str | Path | PathBucket | None = None,
         on_error: Literal["raise", "fail"] = "fail",
     ) -> None:
@@ -808,7 +810,7 @@ class CVEvaluation(EvaluationProtocol):
                 bucket = working_dir
 
         match task_hint:
-            case "classification" | "regression" | None:
+            case "classification" | "regression" | "auto":
                 task_type = identify_task_type(y, task_hint=task_hint)
             case (
                 "binary"

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -626,9 +626,11 @@ class CVEvaluation(EvaluationProtocol):
     from amltk.sklearn import CVEvaluation
     from amltk.pipeline import Component, request
     from amltk.optimization import Metric
+
     from sklearn.ensemble import RandomForestClassifier
     from sklearn.metrics import get_scorer
     from sklearn.datasets import load_iris
+    from pathlib import Path
 
     pipeline = Component(
         RandomForestClassifier,
@@ -636,6 +638,7 @@ class CVEvaluation(EvaluationProtocol):
         space={"n_estimators": (10, 100), "criterion": ["gini", "entropy"]},
     )
 
+    working_dir = Path("./some-path")
     X, y = load_iris(return_X_y=True)
     evaluator = CVEvaluation(
         X,
@@ -645,25 +648,28 @@ class CVEvaluation(EvaluationProtocol):
         additional_scorers={"roc_auc": get_scorer("roc_auc_ovr")},
         store_models=False,
         train_score=True,
+        working_dir=working_dir,
     )
 
     history = pipeline.optimize(
         target=evaluator,
         metric=Metric("accuracy", minimize=False, bounds=(0, 1)),
+        working_dir=working_dir,
     )
     print(history.df())
+    evaluator.working_dir.rmdir()  # Cleanup
     ```
     """
 
     TMP_DIR_PREFIX: ClassVar[str] = "amltk-sklearn-cv-evaluation-data-"
     """Prefix for temporary directory names.
 
-    This is only used when `datadir` is not specified. If not specified
+    This is only used when `working_dir` is not specified. If not specified
     you can control the tmp dir location by setting the `TMPDIR`
     environment variable. By default this is `/tmp`.
 
     When using a temporary directory, it will be deleted by default,
-    controlled by the `delete_datadir=` argument.
+    controlled by the `delete_working_dir=` argument.
     """
 
     _X_FILENAME: ClassVar[str] = "X.pkl"
@@ -752,7 +758,7 @@ class CVEvaluation(EvaluationProtocol):
         random_state: Seed | None = None,  # Only used if cv is an int/float
         params: Mapping[str, Any] | None = None,
         task_hint: TaskTypeName | Literal["classification", "regression"] | None = None,
-        datadir: str | Path | PathBucket | None = None,
+        working_dir: str | Path | PathBucket | None = None,
         on_error: Literal["raise", "fail"] = "fail",
     ) -> None:
         """Initialize the evaluation protocol.
@@ -795,7 +801,7 @@ class CVEvaluation(EvaluationProtocol):
                 If you know this value, it is recommended to provide it as
                 sometimes the target is ambiguous and sklearn may infer
                 incorrectly.
-            datadir: The directory to use for storing data. If not provided,
+            working_dir: The directory to use for storing data. If not provided,
                 a temporary directory will be used. If provided as a string
                 or a `Path`, it will be used as the path to the directory.
             on_error: What to do if an error occurs in the task. This can be
@@ -807,7 +813,7 @@ class CVEvaluation(EvaluationProtocol):
                 even if some trials fail.
         """
         super().__init__()
-        match datadir:
+        match working_dir:
             case None:
                 tmpdir = Path(
                     tempfile.mkdtemp(
@@ -817,9 +823,9 @@ class CVEvaluation(EvaluationProtocol):
                 )
                 databucket = PathBucket(tmpdir)
             case str() | Path():
-                databucket = PathBucket(datadir)
+                databucket = PathBucket(working_dir)
             case PathBucket():
-                databucket = datadir
+                databucket = working_dir
 
         match task_hint:
             case "classification" | "regression" | None:

--- a/src/amltk/store/__init__.py
+++ b/src/amltk/store/__init__.py
@@ -12,7 +12,7 @@ from amltk.store.paths.path_loaders import (
     TxtLoader,
     YAMLLoader,
 )
-from amltk.store.stored_value import StoredValue
+from amltk.store.stored import Stored
 
 __all__ = [
     "Bucket",
@@ -27,5 +27,5 @@ __all__ = [
     "TxtLoader",
     "ByteLoader",
     "PathLoader",
-    "StoredValue",
+    "Stored",
 ]

--- a/src/amltk/store/bucket.py
+++ b/src/amltk/store/bucket.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from collections.abc import (
-    Callable,
     Hashable,
     Iterable,
     Iterator,
@@ -243,22 +242,16 @@ class Bucket(ABC, MutableMapping[KeyT, Drop[LinkT]], Generic[KeyT, LinkT]):
         for key, value in items.items():
             self[key].put(value)
 
-    def remove(
-        self,
-        keys: Iterable[KeyT],
-        *,
-        how: Callable[[LinkT], bool] | None = None,
-    ) -> dict[KeyT, bool]:
+    def remove(self, keys: Iterable[KeyT]) -> dict[KeyT, bool]:
         """Remove resources from the bucket.
 
         Args:
             keys: The keys to the resources.
-            how: A function that removes the resource.
 
         Returns:
             A mapping of keys to whether they were removed.
         """
-        return {key: self[key].remove(how=how) for key in keys}
+        return {key: self[key].remove() for key in keys}
 
     def __truediv__(self, key: KeyT) -> Self:
         try:

--- a/src/amltk/store/drop.py
+++ b/src/amltk/store/drop.py
@@ -61,14 +61,14 @@ class Drop(Generic[KeyT]):
     _exists: Callable[[KeyT], bool] = field(repr=False)
 
     def as_stored(self, read: Callable[[KeyT], T] | None = None) -> Stored[T]:
-        """Convert the drop to a [`StoredValue`][amltk.store.StoredValue].
+        """Convert the drop to a [`Stored`][amltk.store.Stored].
 
         Args:
             read: The method to use to load the resource. If `None` then
                 the first loader that can load the resource will be used.
 
         Returns:
-            The drop as a [`StoredValue`][amltk.store.StoredValue].
+            The drop as a [`Stored`][amltk.store.Stored].
         """
         if read is None:
             loader = first(

--- a/src/amltk/store/drop.py
+++ b/src/amltk/store/drop.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 
 from more_itertools.more import first
 
-from amltk._functional import funcname
-from amltk.store.stored_value import StoredValue
+from amltk.store.stored import Stored
 
 if TYPE_CHECKING:
     from amltk.store.loader import Loader
@@ -38,16 +37,9 @@ class Drop(Generic[KeyT]):
     to use. Each drop has a list of default loaders that it will
     try to use to load the resource.
 
-    For flexibility, you can also specify a `how` when using any
-    of [`load`][amltk.store.drop.Drop.load], [`get`][amltk.store.drop.Drop.get]
-    or [`put`][amltk.store.drop.Drop.put] to override the default loaders.
-    The [`remove`][amltk.store.drop.Drop.remove] and
-    [`exists`][amltk.store.drop.Drop.exists] method also has a `how`
-    incase the default methods are not sufficient.
-
     To support well typed code, you can also specify a `check` type
     which will be used to checked when loading objects, to make sure
-    it is of the correct type. This is ignored if `how` is specified.
+    it is of the correct type.
 
 
     The primary methods of interest are
@@ -56,7 +48,7 @@ class Drop(Generic[KeyT]):
     * [`put`][amltk.store.drop.Drop.put]
     * [`remove`][amltk.store.drop.Drop.remove]
     * [`exists`][amltk.store.drop.Drop.exists]
-    * [`as_stored_value`][amltk.store.drop.Drop.as_stored_value]
+    * [`as_stored`][amltk.store.drop.Drop.as_stored]
 
     Args:
         key: The key to the resource.
@@ -68,10 +60,7 @@ class Drop(Generic[KeyT]):
     _remove: Callable[[KeyT], bool] = field(repr=False)
     _exists: Callable[[KeyT], bool] = field(repr=False)
 
-    def as_stored_value(
-        self,
-        read: Callable[[KeyT], T] | None = None,
-    ) -> StoredValue[KeyT, T]:
+    def as_stored(self, read: Callable[[KeyT], T] | None = None) -> Stored[T]:
         """Convert the drop to a [`StoredValue`][amltk.store.StoredValue].
 
         Args:
@@ -92,26 +81,14 @@ class Drop(Generic[KeyT]):
 
             read = loader.load
 
-        return StoredValue(self.key, read=read)
+        return Stored(self.key, read=read)
 
-    def put(
-        self,
-        obj: T,
-        *,
-        how: Callable[[T], None] | None = None,
-    ) -> None:
+    def put(self, obj: T) -> Stored[T]:
         """Put an object into the bucket.
 
         Args:
             obj: The object to put into the bucket.
-            how: The function to use to put the object into the bucket.
-                If `None` then the first loader that can put the object
-                will be used.
         """
-        if how:
-            how(obj)
-            return
-
         loader = first(
             (_l for _l in self.loaders if _l.can_save(obj, self.key)),
             default=None,
@@ -119,54 +96,40 @@ class Drop(Generic[KeyT]):
         if not loader:
             msg = (
                 f"No default way to handle {type(obj)=} objects."
-                " Please provide a `how` function that will save"
-                f" the object to {self.key}."
+                " Please provide a `Loader` with your `Bucket` to specify"
+                f" how to handle this type of object with this extension: {self.key}."
             )
             raise ValueError(msg)
 
-        loader.save(obj, self.key)
+        return loader.save(obj, self.key)
 
     @overload
-    def load(self, *, check: None = None, how: None = None) -> Any:
+    def load(self, *, check: None = None) -> Any:
         ...
 
     @overload
-    def load(self, *, check: type[T], how: None = None) -> T:
+    def load(self, *, check: type[T]) -> T:
         ...
 
-    @overload
-    def load(self, *, check: type[T] | None = ..., how: Callable[[KeyT], T]) -> T:
-        ...
-
-    def load(
-        self,
-        *,
-        check: type[T] | None = None,
-        how: Callable[[KeyT], T] | None = None,
-    ) -> T | Any:
+    def load(self, *, check: type[T] | None = None) -> T | Any:
         """Load the resource.
 
         Args:
             check: By specifying a `type` we check the loaded object of that type, to
                 enable correctly typed checked code.
-            how: The function to use to load the resource.
 
         Returns:
             The loaded resource.
         """
-        if not isinstance(how, type) and callable(how):
-            value = how(self.key)
-            loader_name = funcname(how)
-        else:
-            loader = first(
-                (_l for _l in self.loaders if _l.can_load(self.key)),
-                default=None,
-            )
-            if loader is None:
-                raise ValueError(f"Can't load {self.key=} from {self.loaders=}")
+        loader = first(
+            (_l for _l in self.loaders if _l.can_load(self.key)),
+            default=None,
+        )
+        if loader is None:
+            raise ValueError(f"Can't load {self.key=} from {self.loaders=}")
 
-            value = loader.load(self.key)
-            loader_name = loader.name
+        value = loader.load(self.key)
+        loader_name = loader.name
 
         if check is not None and not isinstance(value, check):
             msg = (
@@ -178,53 +141,19 @@ class Drop(Generic[KeyT]):
         return value
 
     @overload
-    def get(
-        self,
-        default: None = None,
-        *,
-        check: None = None,
-        how: None = None,
-    ) -> Any | None:
+    def get(self, default: None = None, *, check: None = None) -> Any | None:
         ...
 
     @overload
-    def get(
-        self,
-        default: Default,
-        *,
-        check: None = None,
-        how: None = None,
-    ) -> Default | None:
+    def get(self, default: Default, *, check: None = None) -> Any | Default:
         ...
 
     @overload
-    def get(
-        self,
-        default: None = None,
-        *,
-        check: type[T],
-        how: Callable[[KeyT], T] = ...,
-    ) -> T | None:
+    def get(self, default: None = None, *, check: type[T]) -> T | None:
         ...
 
     @overload
-    def get(
-        self,
-        default: Default,
-        *,
-        check: type[T],
-        how: Callable[[KeyT], T],
-    ) -> Default | T:
-        ...
-
-    @overload
-    def get(
-        self,
-        default: Default,
-        *,
-        check: type[T],
-        how: Callable[[KeyT], T] | None = ...,
-    ) -> Default | T:
+    def get(self, default: Default, *, check: type[T]) -> T | Default:
         ...
 
     def get(
@@ -232,7 +161,6 @@ class Drop(Generic[KeyT]):
         default: Default | None = None,
         *,
         check: type[T] | None = None,
-        how: Callable[[KeyT], T] | None = None,
     ) -> Default | T | None:
         """Load the resource, or return the default if it can't be loaded.
 
@@ -249,13 +177,12 @@ class Drop(Generic[KeyT]):
                 enable correctly typed checked code. If the default value should
                 be returned because the resource can't be loaded, then the default
                 value is **not** checked.
-            how: The function to use to load the resource.
 
         Returns:
             The loaded resource or the default value if it cant be loaded.
         """
         try:
-            return self.load(check=check, how=how)
+            return self.load(check=check)
         except TypeError as e:
             raise e
         except FileNotFoundError:
@@ -268,29 +195,19 @@ class Drop(Generic[KeyT]):
 
         return None
 
-    def remove(self, *, how: Callable[[KeyT], bool] | None = None) -> bool:
+    def remove(self) -> bool:
         """Remove the resource from the bucket.
 
-        Args:
-            how: The function to use to remove the resource. Returns `True` if
-                the resource no longer exists after the removal, `False` otherwise.
+        !!! note "Non-existent resources"
 
-                !!! note "Non-existent resources"
-
-                    If the resource does not exist, then the function will `True`.
+            If the resource does not exist, then the function will return `True`.
         """
-        logger.debug(f"Removing {self.key=}")
-        if how:
-            return how(self.key)
-
         return self._remove(self.key)
 
-    def exists(self, *, how: Callable[[KeyT], bool] | None = None) -> bool:
+    def exists(self) -> bool:
         """Check if the resource exists.
 
         Returns:
             `True` if the resource exists, `False` otherwise.
         """
-        if how:
-            return how(self.key)
         return self._exists(self.key)

--- a/src/amltk/store/loader.py
+++ b/src/amltk/store/loader.py
@@ -8,9 +8,13 @@ module.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from amltk.store.stored import Stored
 
 T = TypeVar("T")
+L = TypeVar("L")
 KeyT_contra = TypeVar("KeyT_contra", contravariant=True)
 
 
@@ -56,7 +60,7 @@ class Loader(ABC, Generic[KeyT_contra, T]):
 
     @classmethod
     @abstractmethod
-    def save(cls, obj: Any, key: KeyT_contra, /) -> None:
+    def save(cls, obj: Any, key: KeyT_contra, /) -> Stored[T]:
         """Save an object to under the given key.
 
         Args:

--- a/src/amltk/store/stored.py
+++ b/src/amltk/store/stored.py
@@ -9,33 +9,32 @@ from pathlib import Path
 
 df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 path = Path("df.csv")
-df.to_csv(path)
 
-stored_value = Stored(path, read=pd.read_csv)
+df.to_csv(path)
+stored_df = Stored(path, read=pd.read_csv)
 
 # Somewhere in a processes
-df = stored_value.value()
+df = stored_df.load()
 print(df)
-
-path.unlink()
+path.unlink()  # markdown-exec: hide
 ```
 
-You can quickly obtain these from buckets if you require
+You can quickly obtain these from buckets if you require using
+[`put()`][amltk.store.drop.Drop.put].
+
 ```python exec="true" source="material-block" result="python" title="Stored from bucket"
 from amltk import PathBucket
 import pandas as pd
 
 df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 bucket = PathBucket("bucket_path")
-bucket.update({"df.csv": df})
 
-stored_value = bucket["df.csv"].as_stored()
+stored_df = bucket["df.csv"].put(df)
 
 # Somewhere in a processes
-df = stored_value.load()
+df = stored_df.load()
 print(df)
-
-bucket.rmdir()
+bucket.rmdir()  # markdown-exec: hide
 ```
 """
 from __future__ import annotations

--- a/tests/optimizers/test_history.py
+++ b/tests/optimizers/test_history.py
@@ -55,35 +55,65 @@ def case_empty() -> list[Trial.Report]:
 
 
 @case(tags=["success"])
-def case_one_report_success() -> list[Trial.Report]:
-    trial: Trial = Trial.create(name="trial_1", config={"x": 1}, metrics=metrics)
+def case_one_report_success(tmp_path: Path) -> list[Trial.Report]:
+    trial: Trial = Trial.create(
+        name="trial_1",
+        config={"x": 1},
+        metrics=metrics,
+        bucket=tmp_path,
+    )
     return eval_trial(trial)
 
 
 @case(tags=["fail"])
-def case_one_report_fail() -> list[Trial.Report]:
-    trial: Trial = Trial.create(name="trial_1", config={"x": 1}, metrics=metrics)
+def case_one_report_fail(tmp_path: Path) -> list[Trial.Report]:
+    trial: Trial = Trial.create(
+        name="trial_1",
+        config={"x": 1},
+        metrics=metrics,
+        bucket=tmp_path,
+    )
     return eval_trial(trial, fail=100)
 
 
 @case(tags=["crash"])
-def case_one_report_crash() -> list[Trial.Report]:
-    trial: Trial = Trial.create(name="trial_1", config={"x": 1}, metrics=metrics)
+def case_one_report_crash(tmp_path: Path) -> list[Trial.Report]:
+    trial: Trial = Trial.create(
+        name="trial_1",
+        config={"x": 1},
+        metrics=metrics,
+        bucket=tmp_path,
+    )
     return eval_trial(trial, crash=ValueError("Some Error"))
 
 
 @case(tags=["success", "fail", "crash"])
-def case_many_report() -> list[Trial.Report]:
+def case_many_report(tmp_path: Path) -> list[Trial.Report]:
     success_trials: list[Trial] = [
-        Trial.create(name=f"trial_{i+6}", config={"x": i}, metrics=metrics)
+        Trial.create(
+            name=f"trial_{i+6}",
+            config={"x": i},
+            metrics=metrics,
+            bucket=tmp_path,
+        )
         for i in range(-5, 5)
     ]
     fail_trials: list[Trial] = [
-        Trial.create(name=f"trial_{i+16}", config={"x": i}, metrics=metrics)
+        Trial.create(
+            name=f"trial_{i+16}",
+            config={"x": i},
+            metrics=metrics,
+            bucket=tmp_path,
+        )
         for i in range(-5, 5)
     ]
     crash_trials: list[Trial] = [
-        Trial.create(name=f"trial_{i+26}", config={"x": i}, metrics=metrics)
+        Trial.create(
+            name=f"trial_{i+26}",
+            config={"x": i},
+            metrics=metrics,
+            bucket=tmp_path,
+        )
         for i in range(-5, 5)
     ]
 
@@ -165,9 +195,14 @@ def test_trace_sortby(reports: list[Trial.Report]) -> None:
     )
 
 
-def test_history_sortby() -> None:
+def test_history_sortby(tmp_path: Path) -> None:
     trials: list[Trial] = [
-        Trial.create(name=f"trial_{i+6}", metrics=metrics, config={"x": i})
+        Trial.create(
+            name=f"trial_{i+6}",
+            metrics=metrics,
+            config={"x": i},
+            bucket=tmp_path,
+        )
         for i in range(-5, 5)
     ]
 
@@ -196,9 +231,14 @@ def test_history_sortby() -> None:
     assert sorted(losses) == losses
 
 
-def test_history_best() -> None:
+def test_history_best(tmp_path: Path) -> None:
     trials: list[Trial] = [
-        Trial.create(name=f"trial_{i}", metrics=metrics, config={"x": i})
+        Trial.create(
+            name=f"trial_{i}",
+            metrics=metrics,
+            config={"x": i},
+            bucket=tmp_path,
+        )
         for i in range(10)
     ]
 
@@ -216,7 +256,7 @@ def test_history_best() -> None:
     assert best.values["loss"] == 1
 
 
-def test_history_incumbents() -> None:
+def test_history_incumbents(tmp_path: Path) -> None:
     m1 = Metric("score", minimize=False)
     m2 = Metric("loss", minimize=True)
     trials: list[Trial] = [
@@ -224,6 +264,7 @@ def test_history_incumbents() -> None:
             name=f"trial_{i+6}",
             metrics={"score": m1, "loss": m2},
             config={"x": i},
+            bucket=tmp_path / "bucket",
         )
         for i in [0, -1, 2, -3, 4, -5, 6, -7, 8, -9]
     ]

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -347,6 +347,7 @@ def test_evaluator(
         params=item.params,
         additional_scorers=item.additional_scorers,
         task_hint=item.task_type,
+        random_state=42,
         on_error="raise",
         **cv_kwargs,  # type: ignore
     )

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -13,8 +14,6 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.metrics import get_scorer
 from sklearn.metrics._scorer import _Scorer
 from sklearn.model_selection import (
-    BaseCrossValidator,
-    BaseShuffleSplit,
     KFold,
     ShuffleSplit,
     StratifiedKFold,
@@ -23,34 +22,58 @@ from sklearn.model_selection import (
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from amltk.optimization.trial import Metric, Trial
-from amltk.pipeline import Component
+from amltk.pipeline import Component, request
 from amltk.sklearn.evaluation import (
     CVEvaluation,
+    ImplicitMetricConversionWarning,
     TaskTypeName,
+    TaskTypeWarning,
     _default_cv_resampler,
     _default_holdout,
     identify_task_type,
 )
 
 
+# NOTE: We can cache this as it doesn't get changed
+@cache
 def data_for_task_type(task_type: TaskTypeName) -> tuple[np.ndarray, np.ndarray]:
     match task_type:
         case "binary":
-            return make_classification(random_state=42, n_classes=2, n_informative=3)  # type: ignore
+            return make_classification(
+                random_state=42,
+                n_samples=20,
+                n_classes=2,
+                n_informative=3,
+            )  # type: ignore
         case "multiclass":
-            return make_classification(random_state=42, n_classes=4, n_informative=3)  # type: ignore
+            return make_classification(
+                random_state=42,
+                n_samples=20,
+                n_classes=4,
+                n_informative=3,
+            )  # type: ignore
         case "multilabel-indicator":
-            x, y = make_classification(random_state=42, n_classes=2, n_informative=3)
+            x, y = make_classification(
+                random_state=42,
+                n_samples=20,
+                n_classes=2,
+                n_informative=3,
+            )
             y = np.vstack([y, y]).T
             return x, y  # type: ignore
         case "multiclass-multioutput":
-            x, y = make_classification(random_state=42, n_classes=4, n_informative=3)
+            x, y = make_classification(
+                random_state=42,
+                n_samples=20,
+                n_classes=4,
+                n_informative=3,
+            )
             y = np.vstack([y, y, y]).T
             return x, y  # type: ignore
         case "continuous":
-            return make_regression(random_state=42, n_targets=1)  # type: ignore
+            return make_regression(random_state=42, n_samples=20, n_targets=1)  # type: ignore
         case "continuous-multioutput":
-            return make_regression(random_state=42, n_targets=2)  # type: ignore
+            return make_regression(random_state=42, n_samples=20, n_targets=2)  # type: ignore
 
     raise ValueError(f"Unknown task type {task_type}")
 
@@ -60,54 +83,84 @@ def _sample_y(task_type: TaskTypeName) -> np.ndarray:
 
 
 @parametrize(
-    "y, is_classification, expected",
+    "real, task_hint, expected",
     [
-        # with is_classification = None
-        # --- classification
-        (_sample_y("binary"), None, "binary"),
-        (_sample_y("multiclass"), None, "multiclass"),
-        (_sample_y("multilabel-indicator"), None, "multilabel-indicator"),
-        (_sample_y("multiclass-multioutput"), None, "multiclass-multioutput"),
-        # --- regression
-        (_sample_y("continuous"), None, "continuous"),
-        (_sample_y("continuous-multioutput"), None, "continuous-multioutput"),
-        # with is_classification = True
-        # --- classification
-        (_sample_y("binary"), True, "binary"),
-        (_sample_y("multiclass"), True, "multiclass"),
-        (_sample_y("multilabel-indicator"), True, "multilabel-indicator"),
-        (_sample_y("multiclass-multioutput"), True, "multiclass-multioutput"),
-        # --- regression
-        (_sample_y("multiclass"), True, "multiclass"),
-        (_sample_y("multiclass-multioutput"), True, "multiclass-multioutput"),
-        # with is_classification = False
-        # --- classification
-        (_sample_y("continuous"), False, "continuous"),
-        (_sample_y("continuous"), False, "continuous"),
-        (_sample_y("continuous-multioutput"), False, "continuous-multioutput"),
-        (_sample_y("continuous-multioutput"), False, "continuous-multioutput"),
-        # --- regression
-        (_sample_y("continuous"), False, "continuous"),
-        (_sample_y("continuous-multioutput"), False, "continuous-multioutput"),
+        ("binary", None, "binary"),
+        ("binary", "classification", "binary"),
+        ("binary", "regression", "continuous"),
+        #
+        ("multiclass", None, "multiclass"),
+        ("multiclass", "classification", "multiclass"),
+        ("multiclass", "regression", "continuous"),
+        #
+        ("multilabel-indicator", None, "multilabel-indicator"),
+        ("multilabel-indicator", "classification", "multilabel-indicator"),
+        ("multilabel-indicator", "regression", "continuous-multioutput"),
+        #
+        ("multiclass-multioutput", None, "multiclass-multioutput"),
+        ("multiclass-multioutput", "classification", "multiclass-multioutput"),
+        ("multiclass-multioutput", "regression", "continuous-multioutput"),
+        #
+        ("continuous", None, "continuous"),
+        ("continuous", "classification", "multiclass"),
+        ("continuous", "regression", "continuous"),
+        #
+        ("continuous-multioutput", None, "continuous-multioutput"),
+        ("continuous-multioutput", "classification", "multiclass-multioutput"),
+        ("continuous-multioutput", "regression", "continuous-multioutput"),
     ],
 )
 def test_identify_task_type(
-    y: np.ndarray,
-    is_classification: bool,
-    expected: str,
+    real: TaskTypeName,
+    task_hint: Literal["classification", "regression"] | None,
+    expected: TaskTypeName,
 ) -> None:
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=UserWarning)
-        identified = identify_task_type(y, is_classification=is_classification)
+        warnings.filterwarnings("ignore", category=TaskTypeWarning)
 
-    assert identified == expected
+        if real == "continuous-multioutput" and task_hint == "classification":
+            # Special case since we have to check when the y with multiple values.
+            A, B, C = 0.1, 2.1, 3.1
 
-    pd_y = pd.Series(y) if np.ndim(y) == 1 else pd.DataFrame(y)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=UserWarning)
-        identified = identify_task_type(pd_y, is_classification=is_classification)
+            # <=2 unique values per column
+            y = np.array(
+                [
+                    [A, B],
+                    [A, B],
+                    [A, C],
+                ],
+            )
 
-    assert identified == expected
+            identified = identify_task_type(y, task_hint=task_hint)
+            assert identified == "multilabel-indicator"
+
+            # >2 unique values per column
+            y = np.array(
+                [
+                    [A, A],
+                    [B, B],
+                    [C, C],
+                ],
+            )
+            identified = identify_task_type(y, task_hint=task_hint)
+            assert identified == "multiclass-multioutput"
+
+        elif real == "continuous" and task_hint == "classification":
+            # Special case since we have to check when the y with multiple values.
+            A, B, C = 0.1, 2.1, 3.1
+
+            y = np.array([A, A, B, B])
+            identified = identify_task_type(y, task_hint=task_hint)
+            assert identified == "binary"
+
+            y = np.array([A, B, C])
+            identified = identify_task_type(y, task_hint=task_hint)
+            assert identified == "multiclass"
+        else:
+            y = _sample_y(expected)
+            identified = identify_task_type(y, task_hint=task_hint)
+
+            assert identified == expected
 
 
 @parametrize(
@@ -150,12 +203,12 @@ def test_default_resampling(task_type: TaskTypeName, expected: type) -> None:
 
 
 @dataclass
-class _EvalutionCase:
+class _EvalKwargs:
     trial: Trial
     pipeline: Component
-    cv: int | float | BaseShuffleSplit | BaseCrossValidator
     additional_scorers: Mapping[str, _Scorer] | None
     params: Mapping[str, Any] | None
+    task_type: TaskTypeName
     datadir: Path
     X: pd.DataFrame | np.ndarray
     y: pd.Series | np.ndarray | pd.DataFrame
@@ -185,16 +238,14 @@ class _EvalutionCase:
     "task_type",
     ["binary", "multiclass", "multilabel-indicator"],
 )
-@parametrize("cv", [3, 0.3])
 def case_classification(
     tmp_path: Path,
     metric: Metric | list[Metric],
     additional_scorers: Mapping[str, _Scorer] | None,
     task_type: TaskTypeName,
-    cv: int | float | BaseShuffleSplit | BaseCrossValidator,
-) -> _EvalutionCase:
+) -> _EvalKwargs:
     x, y = data_for_task_type(task_type)
-    return _EvalutionCase(
+    return _EvalKwargs(
         trial=Trial.create(
             name="test",
             config={},
@@ -202,8 +253,8 @@ def case_classification(
             bucket=tmp_path / "trial",
             metrics=metric,
         ),
+        task_type=task_type,
         pipeline=Component(DecisionTreeClassifier, config={"max_depth": 1}),
-        cv=cv,
         additional_scorers=additional_scorers,
         params=None,
         datadir=tmp_path / "data",
@@ -236,22 +287,15 @@ def case_classification(
     ],
 )
 @parametrize("task_type", ["continuous", "continuous-multioutput"])
-@parametrize("cv_value, strategy", [(3, "cv"), (0.3, "holdout")])
 def case_regression(
     tmp_path: Path,
     metric: Metric | list[Metric],
     additional_scorers: Mapping[str, _Scorer] | None,
     task_type: TaskTypeName,
-    cv_value: int | float,
-    strategy: str,
-) -> _EvalutionCase:
+) -> _EvalKwargs:
     x, y = data_for_task_type(task_type)
-    if strategy == "cv":
-        cv_kwargs = {"n_splits": cv_value, "strategy": "cv"}
-    else:
-        cv_kwargs = {"holdout_size": cv_value, "strategy": "holdout"}
 
-    return _EvalutionCase(
+    return _EvalKwargs(
         trial=Trial.create(
             name="test",
             config={},
@@ -261,11 +305,11 @@ def case_regression(
         ),
         pipeline=Component(DecisionTreeRegressor, config={"max_depth": 1}),
         additional_scorers=additional_scorers,
+        task_type=task_type,
         params=None,
         datadir=tmp_path / "data",
         X=x,
         y=y,
-        **cv_kwargs,
     )
 
 
@@ -273,12 +317,12 @@ def case_regression(
 @parametrize("store_models", [True, False])
 @parametrize("train_score", [True, False])
 @parametrize_with_cases("item", cases=".", prefix="case_")
-@parametrize("cv_value, strategy", [(3, "cv"), (0.3, "holdout")])
+@parametrize("cv_value, strategy", [(2, "cv"), (0.3, "holdout")])
 def test_evaluator(
     as_pd: bool,
     store_models: bool,
     train_score: bool,
-    item: _EvalutionCase,
+    item: _EvalKwargs,
     cv_value: int | float,
     strategy: str,
 ) -> None:
@@ -302,7 +346,9 @@ def test_evaluator(
         store_models=store_models,
         params=item.params,
         additional_scorers=item.additional_scorers,
-        **cv_kwargs,
+        task_hint=item.task_type,
+        on_error="raise",
+        **cv_kwargs,  # type: ignore
     )
     n_splits = evaluator.splitter.get_n_splits(x, y)
     assert n_splits is not None
@@ -346,3 +392,105 @@ def test_evaluator(
     assert "cv" in report.profiles
     for i in range(n_splits):
         assert f"cv:fold_{i}" in report.profiles
+
+
+@parametrize(
+    "task_type",
+    [
+        "binary",
+        "multiclass",
+        "multilabel-indicator",
+        "multiclass-multioutput",
+        "continuous",
+        "continuous-multioutput",
+    ],
+)
+@parametrize("cv_value, strategy", [(2, "cv"), (0.3, "holdout")])
+def test_consistent_results_across_seeds(
+    tmp_path: Path,
+    cv_value: int | float,
+    strategy: Literal["cv", "holdout"],
+    task_type: TaskTypeName,
+) -> None:
+    x, y = data_for_task_type(task_type)
+    match task_type:
+        case "binary" | "multiclass" | "multilabel-indicator":
+            pipeline = Component(
+                DecisionTreeClassifier,
+                config={"max_depth": 1, "random_state": request("random_state")},
+            )
+            metric = Metric("accuracy", minimize=False, bounds=(0, 1))
+        case "continuous" | "continuous-multioutput":
+            pipeline = Component(
+                DecisionTreeRegressor,
+                config={"max_depth": 1, "random_state": request("random_state")},
+            )
+            metric = Metric("r2", minimize=True, bounds=(-np.inf, 1))
+        case "multiclass-multioutput":
+            pipeline = Component(
+                DecisionTreeClassifier,
+                config={"max_depth": 1, "random_state": request("random_state")},
+            )
+            # Sklearn doesn't have any multiclass-multioutput metrics
+            metric = Metric(
+                "custom",
+                minimize=False,
+                bounds=(0, 1),
+                fn=lambda y_true, y_pred: (y_pred == y_true).mean().mean(),
+            )
+
+    if strategy == "cv":
+        cv_kwargs = {"n_splits": cv_value, "strategy": "cv"}
+    else:
+        cv_kwargs = {"holdout_size": cv_value, "strategy": "holdout"}
+
+    evaluator_1 = CVEvaluation(
+        X=x,
+        y=y,
+        datadir=tmp_path,
+        random_state=42,
+        train_score=True,
+        store_models=False,
+        task_hint=task_type,
+        params=None,
+        on_error="raise",
+        **cv_kwargs,  # type: ignore
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=ImplicitMetricConversionWarning)
+
+        report_1 = evaluator_1.fn(
+            Trial.create(
+                name="trial-name",
+                config={},
+                seed=50,
+                bucket=tmp_path / "trial-name",
+                metrics=metric,
+            ),
+            pipeline,
+        )
+
+    # Make sure to clean up the bucket for the second
+    # trial as it will have the same name
+    report_1.bucket.rmdir()
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=ImplicitMetricConversionWarning)
+
+        report_2 = evaluator_1.fn(
+            Trial.create(
+                name="trial-name",
+                config={},
+                seed=50,
+                bucket=tmp_path / "trial-name",  # We give a different dir
+                metrics=metric,
+            ),
+            pipeline,
+        )
+
+    # We ignore profiles because they will be different timings
+    # We report.reported_at as they will naturally be different
+    df_1 = report_1.df(profiles=False).drop(columns=["reported_at"])
+    df_2 = report_2.df(profiles=False).drop(columns=["reported_at"])
+    pd.testing.assert_frame_equal(df_1, df_2)

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -21,13 +21,13 @@ from sklearn.model_selection import (
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
+from amltk.exceptions import TaskTypeWarning
 from amltk.optimization.trial import Metric, Trial
 from amltk.pipeline import Component, request
 from amltk.sklearn.evaluation import (
     CVEvaluation,
     ImplicitMetricConversionWarning,
     TaskTypeName,
-    TaskTypeWarning,
     _default_cv_resampler,
     _default_holdout,
     identify_task_type,
@@ -85,34 +85,34 @@ def _sample_y(task_type: TaskTypeName) -> np.ndarray:
 @parametrize(
     "real, task_hint, expected",
     [
-        ("binary", None, "binary"),
+        ("binary", "auto", "binary"),
         ("binary", "classification", "binary"),
         ("binary", "regression", "continuous"),
         #
-        ("multiclass", None, "multiclass"),
+        ("multiclass", "auto", "multiclass"),
         ("multiclass", "classification", "multiclass"),
         ("multiclass", "regression", "continuous"),
         #
-        ("multilabel-indicator", None, "multilabel-indicator"),
+        ("multilabel-indicator", "auto", "multilabel-indicator"),
         ("multilabel-indicator", "classification", "multilabel-indicator"),
         ("multilabel-indicator", "regression", "continuous-multioutput"),
         #
-        ("multiclass-multioutput", None, "multiclass-multioutput"),
+        ("multiclass-multioutput", "auto", "multiclass-multioutput"),
         ("multiclass-multioutput", "classification", "multiclass-multioutput"),
         ("multiclass-multioutput", "regression", "continuous-multioutput"),
         #
-        ("continuous", None, "continuous"),
+        ("continuous", "auto", "continuous"),
         ("continuous", "classification", "multiclass"),
         ("continuous", "regression", "continuous"),
         #
-        ("continuous-multioutput", None, "continuous-multioutput"),
+        ("continuous-multioutput", "auto", "continuous-multioutput"),
         ("continuous-multioutput", "classification", "multiclass-multioutput"),
         ("continuous-multioutput", "regression", "continuous-multioutput"),
     ],
 )
 def test_identify_task_type(
     real: TaskTypeName,
-    task_hint: Literal["classification", "regression"] | None,
+    task_hint: Literal["classification", "regression", "auto"],
     expected: TaskTypeName,
 ) -> None:
     with warnings.catch_warnings():

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -209,7 +209,7 @@ class _EvalKwargs:
     additional_scorers: Mapping[str, _Scorer] | None
     params: Mapping[str, Any] | None
     task_type: TaskTypeName
-    datadir: Path
+    working_dir: Path
     X: pd.DataFrame | np.ndarray
     y: pd.Series | np.ndarray | pd.DataFrame
 
@@ -257,7 +257,7 @@ def case_classification(
         pipeline=Component(DecisionTreeClassifier, config={"max_depth": 1}),
         additional_scorers=additional_scorers,
         params=None,
-        datadir=tmp_path / "data",
+        working_dir=tmp_path / "data",
         X=x,
         y=y,
     )
@@ -307,7 +307,7 @@ def case_regression(
         additional_scorers=additional_scorers,
         task_type=task_type,
         params=None,
-        datadir=tmp_path / "data",
+        working_dir=tmp_path / "data",
         X=x,
         y=y,
     )
@@ -341,7 +341,7 @@ def test_evaluator(
     evaluator = CVEvaluation(
         X=x,
         y=y,
-        datadir=item.datadir,
+        working_dir=item.working_dir,
         train_score=train_score,
         store_models=store_models,
         params=item.params,
@@ -448,7 +448,7 @@ def test_consistent_results_across_seeds(
     evaluator_1 = CVEvaluation(
         X=x,
         y=y,
-        datadir=tmp_path,
+        working_dir=tmp_path,
         random_state=42,
         train_score=True,
         store_models=False,

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pytest_cases import case, parametrize, parametrize_with_cases
+from sklearn.datasets import make_classification, make_regression
+from sklearn.metrics import get_scorer
+from sklearn.metrics._scorer import _Scorer
+from sklearn.model_selection import (
+    BaseCrossValidator,
+    BaseShuffleSplit,
+    KFold,
+    ShuffleSplit,
+    StratifiedKFold,
+    StratifiedShuffleSplit,
+)
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+from amltk.optimization.trial import Metric, Trial
+from amltk.pipeline import Component
+from amltk.sklearn.evaluation import (
+    CVEvaluation,
+    TaskTypeName,
+    _default_resampler,
+    identify_task_type,
+)
+
+
+def data_for_task_type(task_type: TaskTypeName) -> tuple[np.ndarray, np.ndarray]:
+    match task_type:
+        case "binary":
+            return make_classification(random_state=42, n_classes=2, n_informative=3)  # type: ignore
+        case "multiclass":
+            return make_classification(random_state=42, n_classes=4, n_informative=3)  # type: ignore
+        case "multilabel-indicator":
+            x, y = make_classification(random_state=42, n_classes=2, n_informative=3)
+            y = np.vstack([y, y]).T
+            return x, y  # type: ignore
+        case "multiclass-multioutput":
+            x, y = make_classification(random_state=42, n_classes=4, n_informative=3)
+            y = np.vstack([y, y, y]).T
+            return x, y  # type: ignore
+        case "continuous":
+            return make_regression(random_state=42, n_targets=1)  # type: ignore
+        case "continuous-multioutput":
+            return make_regression(random_state=42, n_targets=2)  # type: ignore
+
+
+def _sample_y(task_type: TaskTypeName) -> np.ndarray:
+    return data_for_task_type(task_type)[1]
+
+
+@parametrize(
+    "y, is_classification, expected",
+    [
+        # with is_classification = None
+        # --- classification
+        (_sample_y("binary"), None, "binary"),
+        (_sample_y("multiclass"), None, "multiclass"),
+        (_sample_y("multilabel-indicator"), None, "multilabel-indicator"),
+        (_sample_y("multiclass-multioutput"), None, "multiclass-multioutput"),
+        # --- regression
+        (_sample_y("continuous"), None, "continuous"),
+        (_sample_y("continuous-multioutput"), None, "continuous-multioutput"),
+        # with is_classification = True
+        # --- classification
+        (_sample_y("binary"), True, "binary"),
+        (_sample_y("multiclass"), True, "multiclass"),
+        (_sample_y("multilabel-indicator"), True, "multilabel-indicator"),
+        (_sample_y("multiclass-multioutput"), True, "multiclass-multioutput"),
+        # --- regression
+        (_sample_y("multiclass"), True, "multiclass"),
+        (_sample_y("multiclass-multioutput"), True, "multiclass-multioutput"),
+        # with is_classification = False
+        # --- classification
+        (_sample_y("continuous"), False, "continuous"),
+        (_sample_y("continuous"), False, "continuous"),
+        (_sample_y("continuous-multioutput"), False, "continuous-multioutput"),
+        (_sample_y("continuous-multioutput"), False, "continuous-multioutput"),
+        # --- regression
+        (_sample_y("continuous"), False, "continuous"),
+        (_sample_y("continuous-multioutput"), False, "continuous-multioutput"),
+    ],
+)
+def test_identify_task_type(
+    y: np.ndarray,
+    is_classification: bool,
+    expected: str,
+) -> None:
+    identified = identify_task_type(y, is_classification=is_classification)
+    assert identified == expected
+
+    pd_y = pd.Series(y) if np.ndim(y) == 1 else pd.DataFrame(y)
+    identified = identify_task_type(pd_y, is_classification=is_classification)
+    assert identified == expected
+
+
+@parametrize(
+    "task_type, n_splits, train_size, expected",
+    [
+        # CV - Notable, only binary and multiclass can be stratified
+        ("binary", 3, 0.0, StratifiedKFold),
+        ("multiclass", 3, 0.0, StratifiedKFold),
+        ("multilabel-indicator", 3, 0.0, KFold),
+        ("multiclass-multioutput", 3, 0.0, KFold),
+        ("continuous", 3, 0.0, KFold),
+        ("continuous-multioutput", 3, 0.0, KFold),
+        # Holdout
+        ("binary", 1, 0.3, StratifiedShuffleSplit),  # With only one fold and test size
+        ("multiclass", 1, 0.3, StratifiedShuffleSplit),
+        ("multilabel-indicator", 1, 0.3, ShuffleSplit),
+        ("multiclass-multioutput", 1, 0.3, ShuffleSplit),
+        ("continuous", 1, 0.3, ShuffleSplit),
+        ("continuous-multioutput", 1, 0.3, ShuffleSplit),
+    ],
+)
+def test_default_resampling(
+    task_type: TaskTypeName,
+    n_splits: int,
+    train_size: float,
+    expected: type,
+) -> None:
+    sampler = _default_resampler(
+        task_type,
+        n_splits=n_splits,
+        random_state=42,
+        train_size=train_size,
+    )
+    assert isinstance(sampler, expected)
+    assert sampler.n_splits == n_splits  # type: ignore
+    assert sampler.random_state == 42  # type: ignore
+
+    if train_size != 0.0:
+        assert sampler.train_size == train_size  # type: ignore
+
+
+@dataclass
+class _EvalutionCase:
+    trial: Trial
+    pipeline: Component
+    cv: int | float | BaseShuffleSplit | BaseCrossValidator
+    additional_scorers: Mapping[str, _Scorer] | None
+    params: Mapping[str, Any] | None
+    datadir: Path
+    X: pd.DataFrame | np.ndarray
+    y: pd.Series | np.ndarray | pd.DataFrame
+
+
+@case
+@parametrize(
+    "metric",
+    [
+        # Single ob
+        Metric("accuracy", minimize=False, bounds=(0, 1)),
+        # Mutli obj
+        [
+            Metric("custom", minimize=False, bounds=(0, 1), fn=get_scorer("accuracy")),
+            Metric("roc_auc_ovr", minimize=False, bounds=(0, 1)),
+        ],
+    ],
+)
+@parametrize(
+    "additional_scorers",
+    [
+        None,
+        {"acc": get_scorer("accuracy"), "roc": get_scorer("roc_auc_ovr")},
+    ],
+)
+@parametrize(
+    "task_type",
+    ["binary", "multiclass", "multilabel-indicator"],
+)
+@parametrize("cv", [3, 0.3])
+def case_classification(
+    tmp_path: Path,
+    metric: Metric | list[Metric],
+    additional_scorers: Mapping[str, _Scorer] | None,
+    task_type: TaskTypeName,
+    cv: int | float | BaseShuffleSplit | BaseCrossValidator,
+) -> _EvalutionCase:
+    x, y = data_for_task_type(task_type)
+    return _EvalutionCase(
+        trial=Trial.create(
+            name="test",
+            config={},
+            seed=42,
+            bucket=tmp_path / "trial",
+            metrics=metric,
+        ),
+        pipeline=Component(DecisionTreeClassifier, config={"max_depth": 1}),
+        cv=cv,
+        additional_scorers=additional_scorers,
+        params=None,
+        datadir=tmp_path / "data",
+        X=x,
+        y=y,
+    )
+
+
+@case
+@parametrize(
+    "metric",
+    [
+        # Single ob
+        Metric("neg_mean_absolute_error", minimize=True, bounds=(-np.inf, 0)),
+        # Mutli obj
+        [
+            Metric("custom", minimize=False, bounds=(-np.inf, 1), fn=get_scorer("r2")),
+            Metric("neg_mean_squared_error", minimize=False, bounds=(-np.inf, 0)),
+        ],
+    ],
+)
+@parametrize(
+    "additional_scorers",
+    [
+        None,
+        {
+            "rmse": get_scorer("neg_root_mean_squared_error"),
+            "err": get_scorer("neg_mean_absolute_error"),
+        },
+    ],
+)
+@parametrize("task_type", ["continuous", "continuous-multioutput"])
+@parametrize("cv", [3, 0.3])
+def case_regression(
+    tmp_path: Path,
+    metric: Metric | list[Metric],
+    additional_scorers: Mapping[str, _Scorer] | None,
+    task_type: TaskTypeName,
+    cv: int | float | BaseShuffleSplit | BaseCrossValidator,
+) -> _EvalutionCase:
+    x, y = data_for_task_type(task_type)
+    return _EvalutionCase(
+        trial=Trial.create(
+            name="test",
+            config={},
+            seed=42,
+            bucket=tmp_path / "trial",
+            metrics=metric,
+        ),
+        pipeline=Component(DecisionTreeRegressor, config={"max_depth": 1}),
+        cv=cv,
+        additional_scorers=additional_scorers,
+        params=None,
+        datadir=tmp_path / "data",
+        X=x,
+        y=y,
+    )
+
+
+@parametrize("as_pd", [True, False])
+@parametrize("store_models", [True, False])
+@parametrize("train_score", [True, False])
+@parametrize_with_cases("item", cases=".", prefix="case_")
+def test_evaluator(
+    as_pd: bool,
+    store_models: bool,
+    train_score: bool,
+    item: _EvalutionCase,
+) -> None:
+    x = pd.DataFrame(item.X) if as_pd else item.X
+    y = (
+        item.y
+        if not as_pd
+        else (pd.DataFrame(item.y) if np.ndim(item.y) > 1 else pd.Series(item.y))
+    )
+    trial = item.trial
+
+    evaluator = CVEvaluation(
+        X=x,
+        y=y,
+        cv=item.cv,
+        datadir=item.datadir,
+        train_score=train_score,
+        store_models=store_models,
+        params=item.params,
+        additional_scorers=item.additional_scorers,
+    )
+    n_splits = evaluator.splitter.get_n_splits(x, y)
+    assert n_splits is not None
+
+    report = evaluator.fn(trial, item.pipeline)
+
+    # ------- Property testing
+
+    # Model should be stored
+    if store_models:
+        for i in range(n_splits):
+            assert f"model_{i}.pkl" in report.storage
+
+    # All metrics should be recorded and valid
+    for metric_name, metric in trial.metrics.items():
+        assert metric_name in report.values
+        value = report.values[metric_name]
+        # ... in correct bounds
+        if metric.bounds is not None:
+            assert metric.bounds[0] <= value <= metric.bounds[1]
+
+    # Summary should contain all optimization metrics
+    expected_summary_scorers = [
+        *trial.metrics.keys(),
+        *(item.additional_scorers.keys() if item.additional_scorers else []),
+    ]
+    for metric_name in expected_summary_scorers:
+        for i in range(n_splits):
+            assert f"fold_{i}:{metric_name}" in report.summary
+        assert f"mean_{metric_name}" in report.summary
+        assert f"std_{metric_name}" in report.summary
+
+    if train_score:
+        for metric_name in expected_summary_scorers:
+            for i in range(n_splits):
+                assert f"fold_{i}:train_{metric_name}" in report.summary
+            assert f"train_mean_{metric_name}" in report.summary
+            assert f"train_std_{metric_name}" in report.summary
+
+    # All folds are profiled
+    assert "cv" in report.profiles
+    for i in range(n_splits):
+        assert f"cv:fold_{i}" in report.profiles


### PR DESCRIPTION
This PR mainly introduces the `amltk.sklearn.CVEvaluator`. This is something that can create a `Task[[Trial, Node], Trial.Report]` that can be optimized against for a proto-typical sklearn setup.

```python
from amltk.sklearn import CVEvaluation
from amltk.pipeline import Component, request
from amltk.optimization import Metric
from sklearn.ensemble import RandomForestClassifier
from sklearn.metrics import get_scorer

pipeline = Component(
    RandomForestClassifier,
    config={"random_state": request("random_state")},
    space={"n_estimators": (10, 100), "critera": ["gini", "entropy"]},
)
evaluator = CVEvaluation(
    X,
    y,
    cv=3,
    additional_scorers={"f1": get_scorer("f1")},
    store_models=False,
    train_score=True,
)

history = pipeline.optimize(
    target=evaluator,
    metrics=Metric("accuracy", minimize=False, bounds=(0, 1)),
    n_workers=4,
)
print(history.df())
```

Namely its parameters features:
* Sensible defaults for splitting based on `strategy: Literal["holdout", "cv"]` or pass a custom splitter.
* Options to `train_score: bool = False` or `store_models: bool = False`
* Pass `additional_scorers: dict[str, _Scorer]` for metrics to track other than optimization ones attached to the `Trial`.
* `params: dict[str, Any]` that use [sklearns new metadata routing](https://scikit-learn.org/stable/metadata_routing.html) for things like `sample_weight` and `scorer` params.
    * This uses `scikit-learn>=1.4` and likely means this will enforce a lower bound. I do not want to maintain backwards compatibility.
* `task_hint: bool | None = None` to hint on the task type. This comes up in the AutoML Benchmark where sklearn incorrectly identifies some targets as regression. 

What this gains is correctly setting up tasks, such as serializing data to be passed to workers, managing memory, i.e. not holding all splits/models in memory at once, as well as interacting with sklearn properly, such as setting seeds.

---

### Additional
* Move away from `StoredValue` to just having a `Stored[T]` which you can call `load()` on. Useful for situations where you don't care about where, just give me the `T`

---

### TODOs
* Tests parameters like groups, sample weights and scorers. Will move this to its own issue for the sake of marching onwards.
* Test clustering, theoretically this shouldn't be problematic except for the identify task type part. However the `cross_validate` doesn't care