### PR TITLE
fix(CVEvaluator): When on_error="raise", inform of which trial failed

### DIFF
--- a/src/amltk/exceptions.py
+++ b/src/amltk/exceptions.py
@@ -146,3 +146,9 @@ class MismatchedTaskTypeWarning(TaskTypeWarning):
     """A warning raised when inferred task type with `task_hint` does not
     match the inferred task type from the target data.
     """
+
+
+class TrialError(RuntimeError):
+    """An exception raised when a trial and it meant to be raised directly
+    to the user.
+    """

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -49,6 +49,7 @@ from amltk.exceptions import (
     AutomaticTaskTypeInferredWarning,
     ImplicitMetricConversionWarning,
     MismatchedTaskTypeWarning,
+    TrialError,
 )
 from amltk.optimization.evaluation import EvaluationProtocol
 from amltk.profiling.profiler import Profiler
@@ -564,7 +565,7 @@ def cross_validate_task(  # noqa: D103, PLR0913, C901, PLR0912
     except Exception as e:  # noqa: BLE001
         trial.dump_exception(e)
         if on_error == "raise":
-            raise e
+            raise TrialError(f"Trial failed: {trial}") from e
         return trial.fail(e)
     else:
         mean_val_scores = {k: np.mean(v) for k, v in all_val_scores.items()}

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -564,9 +564,11 @@ def cross_validate_task(  # noqa: D103, PLR0913, C901, PLR0912
 
     except Exception as e:  # noqa: BLE001
         trial.dump_exception(e)
+        report = trial.fail(e)
         if on_error == "raise":
-            raise TrialError(f"Trial failed: {trial}") from e
-        return trial.fail(e)
+            raise TrialError(f"Trial failed: {report}") from e
+
+        return report
     else:
         mean_val_scores = {k: np.mean(v) for k, v in all_val_scores.items()}
         std_val_scores = {k: np.std(v) for k, v in all_val_scores.items()}

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -27,7 +27,7 @@ from sklearn.model_selection import (
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
-from amltk.exceptions import TaskTypeWarning
+from amltk.exceptions import TaskTypeWarning, TrialError
 from amltk.optimization.trial import Metric, Trial
 from amltk.pipeline import Component, request
 from amltk.sklearn.evaluation import (
@@ -565,8 +565,8 @@ def test_splitter_params_get_forwarded(tmp_path: Path) -> None:
             on_error="raise",
         )
         with pytest.raises(
-            ValueError,
-            match="The 'groups' parameter should not be None.",
+            TrialError,
+            match=r"The 'groups' parameter should not be None.",
         ):
             evaluator.fn(trial, pipeline)
 


### PR DESCRIPTION
Previously it would give the error but it was not really clear which trial failed. No it's explicitly in the error.