### PR TITLE
fix(Node): Ensure that parent name does not conflict with children

### DIFF
--- a/src/amltk/exceptions.py
+++ b/src/amltk/exceptions.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 
 import traceback
 from collections.abc import Callable, Iterable, Iterator
-from typing import TYPE_CHECKING, Any, TypeVar
-from typing_extensions import ParamSpec, override
-
-if TYPE_CHECKING:
-    from amltk.pipeline.node import Node
+from typing import Any, TypeVar
+from typing_extensions import ParamSpec
 
 R = TypeVar("R")
 E = TypeVar("E")
@@ -101,22 +98,6 @@ class ComponentBuildError(TypeError):
 
 class DuplicateNamesError(ValueError):
     """Raised when duplicate names are found."""
-
-    def __init__(self, node: Node) -> None:
-        """Initialize the exception.
-
-        Args:
-            node: The node that has children with duplicate names.
-        """
-        super().__init__(node)
-        self.node = node
-
-    @override
-    def __str__(self) -> str:
-        return (
-            f"Duplicate names found in {self.node.name} and can't be handled."
-            f"\nnodes: {[n.name for n in self.node.nodes]}."
-        )
 
 
 class AutomaticThreadPoolCTLWarning(AutomaticParameterWarning):

--- a/src/amltk/pipeline/components.py
+++ b/src/amltk/pipeline/components.py
@@ -9,12 +9,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, overload
 from typing_extensions import Self, override
 
-from more_itertools import all_unique, first_true
+from more_itertools import first_true
 
 from amltk._functional import entity_name, mapping_select
 from amltk.exceptions import (
     ComponentBuildError,
-    DuplicateNamesError,
     NoChoiceMadeError,
     NodeNotFoundError,
 )
@@ -431,10 +430,6 @@ class Sequential(Node[Item, Space]):
         """
         _nodes = tuple(as_node(n) for n in nodes)
 
-        # Perhaps we need to do a deeper check on this...
-        if not all_unique(_nodes, key=lambda node: node.name):
-            raise DuplicateNamesError(self)
-
         if name is None:
             name = f"Seq-{randuid(8)}"
 
@@ -565,11 +560,6 @@ class Choice(Node[Item, Space]):
         _nodes: tuple[Node, ...] = tuple(
             sorted((as_node(n) for n in nodes), key=lambda n: n.name),
         )
-        if not all_unique(_nodes, key=lambda node: node.name):
-            raise ValueError(
-                f"Can't handle nodes as we can not generate a __choice__ for {nodes=}."
-                "\nAll nodes must have a unique name. Please provide a `name=` to them",
-            )
 
         if name is None:
             name = f"Choice-{randuid(8)}"
@@ -837,12 +827,6 @@ class Split(Node[Item, Space]):
         else:
             _nodes = tuple(as_node(n) for n in nodes)
 
-        if not all_unique(_nodes, key=lambda node: node.name):
-            raise ValueError(
-                f"Can't handle nodes they do not all contain unique names, {nodes=}."
-                "\nAll nodes must have a unique name. Please provide a `name=` to them",
-            )
-
         if name is None:
             name = f"Split-{randuid(8)}"
 
@@ -918,11 +902,6 @@ class Join(Node[Item, Space]):
             meta: Any meta information about this node.
         """
         _nodes = tuple(as_node(n) for n in nodes)
-        if not all_unique(_nodes, key=lambda node: node.name):
-            raise ValueError(
-                f"Can't handle nodes they do not all contain unique names, {nodes=}."
-                "\nAll nodes must have a unique name. Please provide a `name=` to them",
-            )
 
         if name is None:
             name = f"Join-{randuid(8)}"

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from amltk.exceptions import RequestNotMetError
+from amltk.exceptions import DuplicateNamesError, RequestNotMetError
 from amltk.pipeline import Choice, Join, Node, Sequential, request
 
 
@@ -172,3 +172,13 @@ def test_walk() -> None:
     ):
         assert node == _exp_node
         assert path == _exp_path
+
+
+def test_node_fails_if_children_with_duplicate_name() -> None:
+    with pytest.raises(DuplicateNamesError):
+        Node(Node(name="child1"), Node(name="child1"), name="node")
+
+
+def test_node_fails_if_child_has_same_name() -> None:
+    with pytest.raises(DuplicateNamesError):
+        Node(Node(name="child1"), Node(name="node"), name="node")


### PR DESCRIPTION
This was causing an issue when configuring, where essentially the parent would steal the configuration of its child.

This problem came about where I had a pipeline named as the estimator, which could be a pretty
easy mistake to make.

```python
Sequential(
	...,
	...,
	Component(
		MLPClassifier,
		name="mlp_classifier",
	),
	name="mlp_classifier",
)
```

I thought it only mattered that all children of a node must have unique names and that would be enough but nope, both the parent and it's children must be uniquily named too.

```python
Traceback (most recent call last):
  File "/home/skantify/code/exps/one.py", line 12, in <module>
    from exps.pipelines import knn_classifier, mlp_classifier, rf_classifier
  File "/home/skantify/code/exps/src/exps/pipelines.py", line 176, in <module>
    mlp_classifier = Sequential(
  File "/home/skantify/code/amltk/src/amltk/pipeline/components.py", line 437, in __init__
    super().__init__(
  File "/home/skantify/code/amltk/src/amltk/pipeline/node.py", line 313, in __init__
    raise DuplicateNamesError(
amltk.exceptions.DuplicateNamesError: Cannot have a child node with the same name as its parent. self.name='mlp_classifier' child.name='mlp_classifier'
```

What's nice about this PR, it can just be explicitly done in the `Node` init and it removes the extraneuous checks from both `Seqeunce` and `Choice` who were basically doing the same thing.