### PR TITLE
feat(sklearn): CVEvaluator allows `configure` and `build` params

### DIFF
--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -662,8 +662,12 @@ class CVEvaluation(EvaluationProtocol):
     evaluator.bucket.rmdir()  # Cleanup
     ```
 
-    If you need to pass dataset specific items to the pipeline, you can do so
-    use the [`request`][amltk.pipeline.request] in the config of your pipeline.
+    If you need to pass specific configuration items to your pipeline during
+    configuration, you can do so using a [`request()`][amltk.pipeline.request]
+    in the config of your pipeline.
+
+    In the below example, we allow the pipeline to be configured with `"n_jobs"`
+    and pass it in to the `CVEvalautor` using the `params` argument.
 
     ```python exec="true" source="material-block" result="python"
     from amltk.sklearn import CVEvaluation
@@ -705,8 +709,6 @@ class CVEvaluation(EvaluationProtocol):
     print(history.df())
     evaluator.bucket.rmdir()  # Cleanup
     ```
-
-    You can use the same technique above to
     """
 
     TMP_DIR_PREFIX: ClassVar[str] = "amltk-sklearn-cv-evaluation-data-"

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -704,7 +704,7 @@ class CVEvaluation(EvaluationProtocol):
         target=evaluator,
         metric=Metric("accuracy"),
         working_dir=working_dir,
-        n_trials=1,
+        max_trials=1,
     )
     print(history.df())
     evaluator.bucket.rmdir()  # Cleanup

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -841,9 +841,24 @@ class CVEvaluation(EvaluationProtocol):
                 You may also additionally include the following as dictionarys:
 
                 * `#!python "configure"`: Parameters to pass to the pipeline
-                    for [`configure()`][amltk.pipeline.Node.configure].
+                    for [`configure()`][amltk.pipeline.Node.configure]. Please
+                    the example in the class docstring for more information.
                 * `#!python "build"`: Parameters to pass to the pipeline for
                     [`build()`][amltk.pipeline.Node.build].
+
+                    ```python
+                    from imblearn.pipeline import Pipeline as ImbalancedPipeline
+                    CVEvaluator(
+                        ...,
+                        params={
+                            "build": {
+                                "builder": "sklearn",
+                                "pipeline_type": ImbalancedPipeline
+                            }
+                        }
+                    )
+                    ```
+
                 * `#!python "transform_context"`: The transform context to use
                     for [`configure()`][amltk.pipeline.Node.configure].
 

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -736,34 +736,6 @@ class _MyPipeline(sklearn.pipeline.Pipeline):
         self.bamboozled = bamboozled
 
 
-def test_custom_build_params_gets_forwarded(tmp_path: Path) -> None:
-    with sklearn_config_context(enable_metadata_routing=True):
-        pipeline = Component(DecisionTreeClassifier, config={"max_depth": 1})
-
-        build_params = {"pipeline_type": _MyPipeline, "bamboozled": "yes"}
-
-        x, y = data_for_task_type("binary")
-        evaluator = CVEvaluation(
-            x,
-            y,
-            params={"build": build_params},
-            working_dir=tmp_path,
-            store_models=True,
-            on_error="raise",
-        )
-        trial = Trial.create(
-            name="test",
-            bucket=tmp_path / "trial",
-            metrics=Metric("accuracy"),
-        )
-
-        report = evaluator.fn(trial, pipeline)
-        model = report.retrieve("model_0.pkl")
-        assert isinstance(model, _MyPipeline)
-        assert hasattr(model, "bamboozled")
-        assert model.bamboozled == "yes"
-
-
 # Used in test below, builds one of the
 # _MyPipeline with a custom parameter that
 # will also get passed in
@@ -788,7 +760,7 @@ def test_custom_builder_can_be_forwarded(tmp_path: Path) -> None:
         evaluator = CVEvaluation(
             x,
             y,
-            params={"builder": _my_custom_builder, "build": {"bamboozled": "yes"}},
+            params={"build": {"builder": _my_custom_builder, "bamboozled": "yes"}},
             working_dir=tmp_path,
             store_models=True,
             on_error="raise",


### PR DESCRIPTION
Cleans up some TODO's and makes the CVEvaluator more flexible for experienced users.
Docstrings provided.

```python
pipeline = Component(
    RandomForestClassifier,
    config={
        # Allow it to be configured with n_jobs
        "n_jobs": request("n_jobs", default=None)
    },
    space={"n_estimators": (10, 100), "criterion": ["gini", "entropy"]},
)

evaluator = CVEvaluation(
    X,
    y,
    # Use the `configure` keyword in params to pass to the `n_jobs`
    # Anything in the pipeline requesting `n_jobs` will get the value
    params={"configure": {"n_jobs": 2}}
)
history = pipeline.optimize(...)
```

Same can be done to interact with `build()`, for example, to build with an `ImblearnPipeline` or use your own custom builder.

```python
from imblearn.pipeline import Pipeline as ImbalancedPipeline
CVEvaluator(
    ...,
    params={
        "build": {
            "builder": "sklearn",
            "pipeline_type": ImbalancedPipeline
        }
    }
)
```

Same exmaples given in docstrings