### PR TITLE
feat: CVEarlyStopping

### DIFF
--- a/docs/api_generator.py
+++ b/docs/api_generator.py
@@ -11,6 +11,13 @@ import mkdocs_gen_files
 
 logger = logging.getLogger(__name__)
 
+# Modules whose members should not include inherited attributes or methods
+# NOTE: Given the current setup, we can only operate at a module level.
+# Ideally we specify options (at least at a module level) and we render
+# them into strings using a yaml parser. For now this is fine though
+NO_INHERITS = ("sklearn.evaluation",)
+TAB = "    "
+
 for path in sorted(Path("src").rglob("*.py")):
     module_path = path.relative_to("src").with_suffix("")
     doc_path = path.relative_to("src").with_suffix(".md")
@@ -27,5 +34,9 @@ for path in sorted(Path("src").rglob("*.py")):
     with mkdocs_gen_files.open(full_doc_path, "w") as fd:
         ident = ".".join(parts)
         fd.write(f"::: {ident}")
+
+        if ident.endswith(NO_INHERITS):
+            fd.write(f"\n{TAB}options:")
+            fd.write(f"\n{TAB}{TAB}inherited_members: false")
 
     mkdocs_gen_files.set_edit_path(full_doc_path, path)

--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -107,8 +107,8 @@ from amltk._doc import doc_print; doc_print(print, scheduler)  # markdown-exec: 
 ### Running the Scheduler
 
 You may have noticed from the above example that there are many events the scheduler will emit,
-such as `@on_start` or `@on_future_done`. One particularly important one is
-[`@on_start`][amltk.scheduling.Scheduler.on_start], an event to signal
+such as `@start` or `@future-done`. One particularly important one is
+[`@start`][amltk.scheduling.Scheduler.on_start], an event to signal
 the scheduler has started and is ready to accept tasks.
 
 ```python exec="true" source="material-block" html="True"
@@ -123,7 +123,7 @@ from amltk._doc import doc_print; doc_print(print, scheduler, output="html", fon
 ```
 
 From the output, we can see that the `print_hello()` function was registered
-to the event `@on_start`, but it was never called and no `#!python "hello"` was printed.
+to the event `@start`, but it was never called and no `#!python "hello"` was printed.
 
 For this to happen, we actually have to [`run()`][amltk.scheduling.Scheduler.run] the scheduler.
 
@@ -140,7 +140,7 @@ scheduler.run()
 from amltk._doc import doc_print; doc_print(print, scheduler, output="html", fontsize="small")  # markdown-exec: hide
 ```
 
-Now the output will show a little yellow number next to the `@on_start`
+Now the output will show a little yellow number next to the `@start`
 and the `print_hello()`, indicating that event was triggered and the callback
 was called.
 
@@ -181,7 +181,7 @@ defining these units of compute, it is beneficial to see how the `Scheduler`
 operates directly with `submit()`, without abstractions.
 
 In the below example, we will use the
-[`@on_future_result`][amltk.scheduling.Scheduler.on_future_result]
+[`@future-result`][amltk.scheduling.Scheduler.on_future_result]
 event to submit more compute once the previous computation has returned a result.
 
 ```python exec="true" source="material-block" html="True" hl_lines="10 13 17"
@@ -221,47 +221,47 @@ for a complete list.
 
 !!! example "`@events`"
 
-    === "`@on_start`"
+    === "`@start`"
 
         ::: amltk.scheduling.Scheduler.on_start
 
-    === "`@on_future_result`"
+    === "`@future-result`"
 
         ::: amltk.scheduling.Scheduler.on_future_result
 
-    === "`@on_future_exception`"
+    === "`@future-exception`"
 
         ::: amltk.scheduling.Scheduler.on_future_exception
 
-    === "`@on_future_submitted`"
+    === "`@future-submitted`"
 
         ::: amltk.scheduling.Scheduler.on_future_submitted
 
-    === "`@on_future_done`"
+    === "`@future-done`"
 
         ::: amltk.scheduling.Scheduler.on_future_done
 
-    === "`@on_future_cancelled`"
+    === "`@future-cancelled`"
 
         ::: amltk.scheduling.Scheduler.on_future_cancelled
 
-    === "`@on_timeout`"
+    === "`@timeout`"
 
         ::: amltk.scheduling.Scheduler.on_timeout
 
-    === "`@on_stop`"
+    === "`@stop`"
 
         ::: amltk.scheduling.Scheduler.on_stop
 
-    === "`@on_finishing`"
+    === "`@finishing`"
 
         ::: amltk.scheduling.Scheduler.on_finishing
 
-    === "`@on_finished`"
+    === "`@finished`"
 
         ::: amltk.scheduling.Scheduler.on_finished
 
-    === "`@on_empty`"
+    === "`@empty`"
 
         ::: amltk.scheduling.Scheduler.on_empty
 
@@ -272,7 +272,7 @@ it was emitted as the values.
 
 ### Controlling Callbacks
 There's a few parameters you can pass to any event subscriber
-such as `@on_start` or `@on_future_result`.
+such as `@start` or `@future-result`.
 These control the behavior of what happens when its event is fired and can
 be used to control the flow of your system.
 
@@ -391,7 +391,7 @@ However, there are more explicit methods.
     scheduler to stop immediately with [`run(wait=False)`][amltk.scheduling.Scheduler.run].
 
     You'll notice this in the event count of the Scheduler where the event
-    `@on_future_cancelled` was fired.
+    `@future-cancelled` was fired.
 
     ```python exec="true" source="material-block" html="True" hl_lines="13-15"
     import time
@@ -420,7 +420,7 @@ However, there are more explicit methods.
     You can also tell the `Scheduler` to stop after a certain amount of time
     with the `timeout=` argument to [`run()`][amltk.scheduling.Scheduler.run].
 
-    This will also trigger the `@on_timeout` event as seen in the `Scheduler` output.
+    This will also trigger the `@timeout` event as seen in the `Scheduler` output.
 
     ```python exec="true" source="material-block" html="True" hl_lines="20"
     import time
@@ -453,7 +453,7 @@ to clarify that there are two kinds of exceptions that can occur within the Sche
 
 The 1st kind that can happen is within some function submitted with
 [`submit()`][amltk.scheduling.Scheduler.submit]. When this happens,
-the `@on_future_exception` will be emitted, passing the exception to the callback.
+the `@future-exception` will be emitted, passing the exception to the callback.
 
 By default, the `Scheduler` will then raise the exception that occurred up to your program
 and end its computations. This is done by setting

--- a/examples/hpo.py
+++ b/examples/hpo.py
@@ -271,7 +271,7 @@ def launch_initial_tasks() -> None:
 When a [`Task`][amltk.Trial] returns and we get a report, i.e.
 with [`task.success()`][amltk.optimization.Trial.success] or
 [`task.fail()`][amltk.optimization.Trial.fail], the `task` will fire off the
-callbacks registered with [`@on_result`][amltk.Task.on_result].
+callbacks registered with [`@result`][amltk.Task.on_result].
 We can use these to add callbacks that get called when these events happen.
 
 Here we use it to update the optimizer with the report we got.

--- a/src/amltk/exceptions.py
+++ b/src/amltk/exceptions.py
@@ -130,6 +130,10 @@ class MismatchedTaskTypeWarning(TaskTypeWarning):
 
 
 class TrialError(RuntimeError):
-    """An exception raised when a trial and it meant to be raised directly
+    """An exception raised from a trial and it is meant to be raised directly
     to the user.
     """
+
+
+class CVEarlyStoppedError(RuntimeError):
+    """An exception raised when a CV evaluation is early stopped."""

--- a/src/amltk/optimization/__init__.py
+++ b/src/amltk/optimization/__init__.py
@@ -1,7 +1,3 @@
-from amltk.optimization.evaluation import (
-    CustomEvaluationProtocol,
-    EvaluationProtocol,
-)
 from amltk.optimization.history import History
 from amltk.optimization.metric import Metric, MetricCollection
 from amltk.optimization.optimizer import Optimizer
@@ -13,6 +9,4 @@ __all__ = [
     "Metric",
     "MetricCollection",
     "History",
-    "EvaluationProtocol",
-    "CustomEvaluationProtocol",
 ]

--- a/src/amltk/optimization/evaluation.py
+++ b/src/amltk/optimization/evaluation.py
@@ -3,30 +3,3 @@
 TODO: Sorry
 """
 from __future__ import annotations
-
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from amltk.optimization import Trial
-    from amltk.pipeline import Node
-
-
-@runtime_checkable
-class EvaluationProtocol(Protocol):
-    """A protocol for how a trial should be evaluated on a pipeline."""
-
-    fn: Callable[[Trial, Node], Trial.Report]
-
-
-class CustomEvaluationProtocol(EvaluationProtocol):
-    """A custom evaluation protocol based on a user function."""
-
-    def __init__(self, fn: Callable[[Trial, Node], Trial.Report]) -> None:
-        """Initialize the protocol.
-
-        Args:
-            fn: The function to use for the evaluation.
-        """
-        super().__init__()
-        self.fn = fn

--- a/src/amltk/optimization/evaluation.py
+++ b/src/amltk/optimization/evaluation.py
@@ -4,46 +4,19 @@ TODO: Sorry
 """
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING
-
-from amltk.scheduling import Plugin
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from amltk.optimization import Trial
     from amltk.pipeline import Node
-    from amltk.scheduling import Scheduler, Task
 
 
-class EvaluationProtocol:
+@runtime_checkable
+class EvaluationProtocol(Protocol):
     """A protocol for how a trial should be evaluated on a pipeline."""
 
     fn: Callable[[Trial, Node], Trial.Report]
-
-    def task(
-        self,
-        scheduler: Scheduler,
-        plugins: Plugin | Iterable[Plugin] | None = None,
-    ) -> Task[[Trial, Node], Trial.Report]:
-        """Create a task for this protocol.
-
-        Args:
-            scheduler: The scheduler to use for the task.
-            plugins: The plugins to use for the task.
-
-        Returns:
-            The created task.
-        """
-        _plugins: tuple[Plugin, ...]
-        match plugins:
-            case None:
-                _plugins = ()
-            case Plugin():
-                _plugins = (plugins,)
-            case Iterable():
-                _plugins = tuple(plugins)
-
-        return scheduler.task(self.fn, plugins=_plugins)
 
 
 class CustomEvaluationProtocol(EvaluationProtocol):

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -343,7 +343,22 @@ class Trial(RichRenderable, Generic[I]):
 
     @property
     def profiles(self) -> Mapping[str, Profile.Interval]:
-        """The profiles of the trial."""
+        """The profiles of the trial.
+
+        These are indexed by the name of the profile indicated by:
+
+        ```python
+        with trial.profile("key_to_index"):
+            # ...
+
+        profile = trial.profiles["key_to_index"]
+        ```
+
+        The values are a [`Profile.Interval`][amltk.profiling.profile.Interval],
+        which contain a [`Memory.Interval`][amltk.profiling.memory.Interval] and
+        a [`Timer.Interval`][amltk.profiling.timer.Interval]. Please see the
+        respective documentation for more.
+        """
         return self.profiler.profiles
 
     def dump_exception(

--- a/src/amltk/optimization/trial.py
+++ b/src/amltk/optimization/trial.py
@@ -354,10 +354,13 @@ class Trial(RichRenderable, Generic[I]):
         profile = trial.profiles["key_to_index"]
         ```
 
-        The values are a [`Profile.Interval`][amltk.profiling.profile.Interval],
-        which contain a [`Memory.Interval`][amltk.profiling.memory.Interval] and
-        a [`Timer.Interval`][amltk.profiling.timer.Interval]. Please see the
-        respective documentation for more.
+        The values are a
+        [`Profile.Interval`][amltk.profiling.profiler.Profile.Interval],
+        which contain a
+        [`Memory.Interval`][amltk.profiling.memory.Memory.Interval]
+        and a
+        [`Timer.Interval`][amltk.profiling.timing.Timer.Interval].
+        Please see the respective documentation for more.
         """
         return self.profiler.profiles
 

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -1157,7 +1157,7 @@ class Node(RichRenderable, Generic[Item, Space]):
             case int() if max_trials > 0:
                 from amltk.scheduling.plugins import Limiter
 
-                _plugins = (*_plugins, Limiter(max_calls=max_trials))
+                _plugins = (*_plugins, Limiter(max_calls=max_trials - 1))
             case _:
                 raise ValueError(f"{max_trials=} must be a positive int")
 

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -1231,6 +1231,7 @@ class Node(RichRenderable, Generic[Item, Space]):
             bucket=working_dir,
             seed=seed,
         )
+        assert _optimizer is not None
 
         if on_begin is not None:
             hook = partial(on_begin, task, scheduler, history)

--- a/src/amltk/pipeline/node.py
+++ b/src/amltk/pipeline/node.py
@@ -1157,7 +1157,7 @@ class Node(RichRenderable, Generic[Item, Space]):
             case int() if max_trials > 0:
                 from amltk.scheduling.plugins import Limiter
 
-                _plugins = (*_plugins, Limiter(max_calls=max_trials - 1))
+                _plugins = (*_plugins, Limiter(max_calls=max_trials))
             case _:
                 raise ValueError(f"{max_trials=} must be a positive int")
 

--- a/src/amltk/scheduling/events.py
+++ b/src/amltk/scheduling/events.py
@@ -664,7 +664,6 @@ class Emitter:
 
         Args:
             event: The event to register the callback for.
-            callback: The callback to register.
             when: A predicate that must be satisfied for the callback to be called.
             every: The callback will be called every `every` times the event is emitted.
             repeat: The callback will be called `repeat` times successively.

--- a/src/amltk/scheduling/plugins/comm.py
+++ b/src/amltk/scheduling/plugins/comm.py
@@ -588,7 +588,11 @@ class Comm:
             else:
                 logger.warning(f"Communication coroutine {coroutine} not found!")
 
-            if (exception := coroutine.exception()) is not None:
+            if coroutine.cancelled():
+                logger.debug(
+                    f"Coroutine {coroutine} was cancelled. Not treated as an error.",
+                )
+            elif (exception := coroutine.exception()) is not None:
                 raise exception
 
         async def _communicate(

--- a/src/amltk/scheduling/plugins/comm.py
+++ b/src/amltk/scheduling/plugins/comm.py
@@ -216,7 +216,8 @@ class Comm:
     from amltk.scheduling import Scheduler
     from amltk.scheduling.plugins import Comm
 
-    def fn(comm: Comm, x: int) -> int:
+    def fn(x: int, comm: Comm | None = None) -> int:
+        assert comm is not None
         with comm.open():
             comm.send(x + 1)
 
@@ -237,7 +238,8 @@ class Comm:
     from amltk.scheduling import Scheduler
     from amltk.scheduling.plugins import Comm
 
-    def greeter(comm: Comm, greeting: str) -> None:
+    def greeter(greeting: str, comm: Comm | None = None) -> None:
+        assert comm is not None
         with comm.open():
             name = comm.request()
             comm.send(f"{greeting} {name}!")

--- a/src/amltk/scheduling/plugins/emissions_tracker_plugin.py
+++ b/src/amltk/scheduling/plugins/emissions_tracker_plugin.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
-from typing_extensions import ParamSpec, Self
+from typing_extensions import ParamSpec
 
 from codecarbon import EmissionsTracker
 
@@ -127,10 +127,6 @@ class EmissionsTrackerPlugin(Plugin):
             **self.codecarbon_kwargs,
         )
         return wrapped_f, args, kwargs
-
-    def copy(self) -> Self:
-        """Return a copy of the plugin."""
-        return self.__class__(*self.codecarbon_args, **self.codecarbon_kwargs)
 
     def __rich__(self) -> Panel:
         """Return a rich panel."""

--- a/src/amltk/scheduling/plugins/plugin.py
+++ b/src/amltk/scheduling/plugins/plugin.py
@@ -41,7 +41,7 @@ that a `Task` emits.
             self.task = task
             # Register an event with the task, this lets the task know valid events
             # people can subscribe to and helps it show up in visuals
-            task.emitter.add_event(self.PRINTED)
+            task.add_event(self.PRINTED)
             task.on_submitted(self._print_submitted, hidden=True)  # You can hide this callback from visuals
 
         def pre_submit(self, fn, *args, **kwargs) -> tuple[Callable, tuple, dict]:
@@ -51,11 +51,7 @@ that a `Task` emits.
 
         def _print_submitted(self, future, *args, **kwargs) -> None:
             msg = f"Task was submitted {self.task} {args} {kwargs}"
-            self.task.emitter.emit(self.PRINTED, msg)  # Emit the event with a msg
-
-        def copy(self) -> Printer:
-            # Plugins need to be able to copy themselves as if fresh
-            return self.__class__(self.greeting)
+            self.task.emit(self.PRINTED, msg)  # Emit the event with a msg
 
         def __rich__(self):
             # Custome how the plugin is displayed in rich (Optional)
@@ -102,11 +98,11 @@ that a `Task` emits.
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Callable
 from itertools import chain
 from typing import TYPE_CHECKING, ClassVar, TypeVar
-from typing_extensions import ParamSpec, Self, override
+from typing_extensions import ParamSpec, override
 
 from amltk._richutil.renderable import RichRenderable
 from amltk.scheduling.events import Event
@@ -179,17 +175,6 @@ class Plugin(RichRenderable, ABC):
             vars(cls).values() for cls in self.__class__.__mro__
         )
         return [attr for attr in inherited_attrs if isinstance(attr, Event)]
-
-    @abstractmethod
-    def copy(self) -> Self:
-        """Return a copy of the plugin.
-
-        This method is used to create a copy of the plugin when a task is
-        copied. This is useful if the plugin stores a reference to the task
-        it is attached to, as the copy will need to store a reference to the
-        copy of the task.
-        """
-        ...
 
     @override
     def __rich__(self) -> Panel:

--- a/src/amltk/scheduling/plugins/threadpoolctl.py
+++ b/src/amltk/scheduling/plugins/threadpoolctl.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
-from typing_extensions import ParamSpec, Self, override
+from typing_extensions import ParamSpec, override
 
 from amltk.scheduling.plugins.plugin import Plugin
 
@@ -136,14 +136,6 @@ class ThreadPoolCTLPlugin(Plugin):
             user_api=self.user_api,
         )
         return fn, args, kwargs
-
-    @override
-    def copy(self) -> Self:
-        """Return a copy of the plugin.
-
-        Please see [`Plugin.copy()`][amltk.Plugin.copy].
-        """
-        return self.__class__(max_threads=self.max_threads, user_api=self.user_api)
 
     @override
     def __rich__(self) -> Panel:

--- a/src/amltk/scheduling/plugins/wandb.py
+++ b/src/amltk/scheduling/plugins/wandb.py
@@ -22,7 +22,7 @@ from typing import (
     TypeAlias,
     TypeVar,
 )
-from typing_extensions import ParamSpec, Self, override
+from typing_extensions import ParamSpec, override
 
 import numpy as np
 import wandb
@@ -231,11 +231,6 @@ class WandbTrialTracker(Plugin):
         """
         fn = WandbLiveRunWrap(self.params, fn, modify=self.modify)  # type: ignore
         return fn, args, kwargs
-
-    @override
-    def copy(self) -> Self:
-        """Copy the plugin."""
-        return self.__class__(modify=self.modify, params=replace(self.params))
 
     def _check_explicit_reinit_arg_with_executor(
         self,

--- a/src/amltk/scheduling/plugins/warning_filter.py
+++ b/src/amltk/scheduling/plugins/warning_filter.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
-from typing_extensions import ParamSpec, Self, override
+from typing_extensions import ParamSpec, override
 
 from amltk.scheduling.plugins.plugin import Plugin
 
@@ -109,11 +109,6 @@ class WarningFilter(Plugin):
         """
         wrapped_f = _IgnoreWarningWrapper(fn, *self.warning_args, **self.warning_kwargs)
         return wrapped_f, args, kwargs
-
-    @override
-    def copy(self) -> Self:
-        """Return a copy of the plugin."""
-        return self.__class__(*self.warning_args, **self.warning_kwargs)
 
     @override
     def __rich__(self) -> Panel:

--- a/src/amltk/scheduling/scheduler.py
+++ b/src/amltk/scheduling/scheduler.py
@@ -1120,8 +1120,8 @@ class Scheduler(RichRenderable):
                         self.stop(
                             stop_msg=(
                                 f"raising on exception '{type(exception)}'"
-                                f" as {err_type} is 'raise' as specified from"
-                                f"`on_exception={self._on_exc_method_map.value}"
+                                f" as scheduler was run with"
+                                f" `on_exception={self._on_exc_method_map.value}"
                             ),
                             exception=exception,
                         )

--- a/src/amltk/scheduling/scheduler.py
+++ b/src/amltk/scheduling/scheduler.py
@@ -32,7 +32,7 @@ responding to computed functions, but rather use a [`Task`][amltk.scheduling.Tas
 
     In this example, we create a scheduler that uses local processes as
     workers. We then create a task that will run a function `fn` and submit it
-    to the scheduler. Lastly, a callback is registered to `@on_future_result` to print the
+    to the scheduler. Lastly, a callback is registered to `@future-result` to print the
     result when the compute is done.
 
     ```python exec="true" source="material-block" html="true"
@@ -58,12 +58,12 @@ responding to computed functions, but rather use a [`Task`][amltk.scheduling.Tas
 
     The last line in the previous example called
     [`scheduler.run()`][amltk.scheduling.Scheduler.run] is what starts the scheduler
-    running, in which it will first emit the `@on_start` event. This triggered the
+    running, in which it will first emit the `@start` event. This triggered the
     callback `launch_the_compute()` which submitted the function `fn` with the
     arguments `#!python 1`.
 
     The scheduler then ran the compute and waited for it to complete, emitting the
-    `@on_future_result` event when it was done successfully. This triggered the callback
+    `@future-result` event when it was done successfully. This triggered the callback
     `callback()` which printed the result.
 
     At this point, there is no more compute happening and no more events to respond to
@@ -76,27 +76,27 @@ responding to computed functions, but rather use a [`Task`][amltk.scheduling.Tas
         When the scheduler enters some important state, it will emit an event
         to let you know.
 
-        === "`@on_start`"
+        === "`@start`"
 
             ::: amltk.scheduling.Scheduler.on_start
 
-        === "`@on_finishing`"
+        === "`@finishing`"
 
             ::: amltk.scheduling.Scheduler.on_finishing
 
-        === "`@on_finished`"
+        === "`@finished`"
 
             ::: amltk.scheduling.Scheduler.on_finished
 
-        === "`@on_stop`"
+        === "`@stop`"
 
             ::: amltk.scheduling.Scheduler.on_stop
 
-        === "`@on_timeout`"
+        === "`@timeout`"
 
             ::: amltk.scheduling.Scheduler.on_timeout
 
-        === "`@on_empty`"
+        === "`@empty`"
 
             ::: amltk.scheduling.Scheduler.on_empty
 
@@ -107,23 +107,23 @@ responding to computed functions, but rather use a [`Task`][amltk.scheduling.Tas
         [`Task`][amltk.scheduling.Task] as it will emit specific events
         for the task at hand, and not all compute.
 
-        === "`@on_future_submitted`"
+        === "`@future-submitted`"
 
             ::: amltk.scheduling.Scheduler.on_future_submitted
 
-        === "`@on_future_result`"
+        === "`@future-result`"
 
             ::: amltk.scheduling.Scheduler.on_future_result
 
-        === "`@on_future_exception`"
+        === "`@future-exception`"
 
             ::: amltk.scheduling.Scheduler.on_future_exception
 
-        === "`@on_future_done`"
+        === "`@future-done`"
 
             ::: amltk.scheduling.Scheduler.on_future_done
 
-        === "`@on_future_cancelled`"
+        === "`@future-cancelled`"
 
             ::: amltk.scheduling.Scheduler.on_future_cancelled
 
@@ -149,7 +149,7 @@ responding to computed functions, but rather use a [`Task`][amltk.scheduling.Tas
         You can tell the `Scheduler` to stop after a certain amount of time
         with the `timeout=` argument to [`run()`][amltk.scheduling.Scheduler.run].
 
-        This will also trigger the `@on_timeout` event as seen in the `Scheduler` output.
+        This will also trigger the `@timeout` event as seen in the `Scheduler` output.
 
         ```python exec="true" source="material-block" html="True" hl_lines="19"
         import time
@@ -312,7 +312,7 @@ class Scheduler(RichRenderable):
     queue: dict[Future, tuple[Callable, tuple, dict]]
     """The queue of tasks running."""
 
-    on_start: Subscriber[[]]
+    on_start: Subscriber[[], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when the
     scheduler starts. This is the first event emitted by the scheduler and
     one of the only ways to submit the initial compute to the scheduler.
@@ -323,7 +323,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_future_submitted: Subscriber[Future]
+    on_future_submitted: Subscriber[[Future], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when
     some compute is submitted.
 
@@ -333,7 +333,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_future_done: Subscriber[Future]
+    on_future_done: Subscriber[[Future], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when
     some compute is done, regardless of whether it was successful or not.
 
@@ -343,7 +343,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_future_result: Subscriber[Future, Any]
+    on_future_result: Subscriber[[Future, Any], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when
     a future returned with a result, no exception raise.
 
@@ -353,7 +353,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_future_exception: Subscriber[Future, BaseException]
+    on_future_exception: Subscriber[[Future, BaseException], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when
     some compute raised an uncaught exception.
 
@@ -363,7 +363,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_future_cancelled: Subscriber[Future]
+    on_future_cancelled: Subscriber[[Future], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called
     when a future is cancelled. This usually occurs due to the underlying Scheduler,
     and is not something we do directly, other than when shutting down the scheduler.
@@ -374,7 +374,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_finishing: Subscriber[[]]
+    on_finishing: Subscriber[[], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when the
     scheduler is finishing up. This occurs right before the scheduler shuts down
     the executor.
@@ -385,7 +385,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_finished: Subscriber[[]]
+    on_finished: Subscriber[[], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when
     the scheduler is finished, has shutdown the executor and possibly
     terminated any remaining compute.
@@ -396,7 +396,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_stop: Subscriber[str, BaseException | None]
+    on_stop: Subscriber[[str, BaseException | None], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when the
     scheduler is has been stopped due to the [`stop()`][amltk.scheduling.Scheduler.stop]
     method being called.
@@ -407,7 +407,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_timeout: Subscriber[[]]
+    on_timeout: Subscriber[[], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when
     the scheduler reaches the timeout.
 
@@ -417,7 +417,7 @@ class Scheduler(RichRenderable):
         ...
     ```
     """
-    on_empty: Subscriber[[]]
+    on_empty: Subscriber[[], Any]
     """A [`Subscriber`][amltk.scheduling.events.Subscriber] which is called when the
     queue is empty. This can be useful to re-fill the queue and prevent the
     scheduler from exiting.
@@ -429,17 +429,19 @@ class Scheduler(RichRenderable):
     ```
     """
 
-    STARTED: Event[[]] = Event("on_start")
-    FINISHING: Event[[]] = Event("on_finishing")
-    FINISHED: Event[[]] = Event("on_finished")
-    STOP: Event[str, BaseException | None] = Event("on_stop")
-    TIMEOUT: Event[[]] = Event("on_timeout")
-    EMPTY: Event[[]] = Event("on_empty")
-    FUTURE_SUBMITTED: Event[Future] = Event("on_future_submitted")
-    FUTURE_DONE: Event[Future] = Event("on_future_done")
-    FUTURE_CANCELLED: Event[Future] = Event("on_future_cancelled")
-    FUTURE_RESULT: Event[Future, Any] = Event("on_future_result")
-    FUTURE_EXCEPTION: Event[Future, BaseException] = Event("on_future_exception")
+    STARTED: Event[[], Any] = Event("on_start")
+    FINISHING: Event[[], Any] = Event("on_finishing")
+    FINISHED: Event[[], Any] = Event("on_finished")
+    STOP: Event[[str, BaseException | None], Any] = Event("on_stop")
+    TIMEOUT: Event[[], Any] = Event("on_timeout")
+    EMPTY: Event[[], Any] = Event("on_empty")
+    FUTURE_SUBMITTED: Event[[Future], Any] = Event("on_future_submitted")
+    FUTURE_DONE: Event[[Future], Any] = Event("on_future_done")
+    FUTURE_CANCELLED: Event[[Future], Any] = Event("on_future_cancelled")
+    FUTURE_RESULT: Event[[Future, Any], Any] = Event("on_future_result")
+    FUTURE_EXCEPTION: Event[[Future, BaseException], Any] = Event(
+        "on_future_exception",
+    )
 
     def __init__(
         self,
@@ -1205,7 +1207,7 @@ class Scheduler(RichRenderable):
                 # Monitor for the queue being empty
                 monitor_empty = asyncio.create_task(self._monitor_queue_empty())
                 if end_on_empty:
-                    self.on_empty(lambda: monitor_empty.cancel(), hidden=True)
+                    self.on_empty.register(lambda: monitor_empty.cancel(), hidden=True)
 
                 # The timeout criterion is satisfied by the `timeout` arg
                 await asyncio.wait(

--- a/src/amltk/scheduling/task.py
+++ b/src/amltk/scheduling/task.py
@@ -16,23 +16,23 @@ with callbacks and act accordingly.
     for more on how to customize these callbacks. You can also take a look
     at the API of [`on()`][amltk.scheduling.task.Task.on] for more information.
 
-    === "`@on_result`"
+    === "`@on-result`"
 
         ::: amltk.scheduling.task.Task.on_result
 
-    === "`@on_exception`"
+    === "`@on-exception`"
 
         ::: amltk.scheduling.task.Task.on_exception
 
-    === "`@on_done`"
+    === "`@on-done`"
 
         ::: amltk.scheduling.task.Task.on_done
 
-    === "`@on_submitted`"
+    === "`@on-submitted`"
 
         ::: amltk.scheduling.task.Task.on_submitted
 
-    === "`@on_cancelled`"
+    === "`@on-cancelled`"
 
         ::: amltk.scheduling.task.Task.on_cancelled
 
@@ -75,15 +75,14 @@ from __future__ import annotations
 import logging
 from asyncio import Future
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, Concatenate, Generic, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Concatenate, Generic, TypeVar
 from typing_extensions import ParamSpec, Self, override
 
-from more_itertools import first_true
+from dask.utils import funcname
 
 from amltk._functional import callstring
 from amltk._richutil.renderable import RichRenderable
-from amltk.exceptions import EventNotKnownError, SchedulerNotRunningError
-from amltk.randomness import randuid
+from amltk.exceptions import SchedulerNotRunningError
 from amltk.scheduling.events import Emitter, Event, Subscriber
 from amltk.scheduling.plugins.plugin import Plugin
 
@@ -103,7 +102,7 @@ R2 = TypeVar("R2")
 CallableT = TypeVar("CallableT", bound=Callable)
 
 
-class Task(RichRenderable, Generic[P, R]):
+class Task(Emitter, RichRenderable, Generic[P, R]):
     """The task class."""
 
     unique_ref: str
@@ -121,7 +120,7 @@ class Task(RichRenderable, Generic[P, R]):
     emitter: Emitter
     """The emitter for events of this task."""
 
-    on_submitted: Subscriber[Concatenate[Future[R], P]]
+    on_submitted: Subscriber[Concatenate[Future[R], P], Any]
     """An event that is emitted when a future is submitted to the
     scheduler. It will pass the future as the first argument with args and
     kwargs following.
@@ -133,7 +132,7 @@ class Task(RichRenderable, Generic[P, R]):
         print(f"Future {future} was submitted with {args=} and {kwargs=}")
     ```
     """
-    on_done: Subscriber[Future[R]]
+    on_done: Subscriber[[Future[R]], Any]
     """Called when a task is done running with a result or exception.
     ```python
     @task.on_done
@@ -141,7 +140,7 @@ class Task(RichRenderable, Generic[P, R]):
         print(f"Future {future} is done")
     ```
     """
-    on_cancelled: Subscriber[Future[R]]
+    on_cancelled: Subscriber[[Future[R]], Any]
     """Called when a task is cancelled.
     ```python
     @task.on_cancelled
@@ -149,7 +148,7 @@ class Task(RichRenderable, Generic[P, R]):
         print(f"Future {future} was cancelled")
     ```
     """
-    on_result: Subscriber[Future[R], R]
+    on_result: Subscriber[[Future[R], R], Any]
     """Called when a task has successfully returned a value.
     Comes with Future
     ```python
@@ -158,7 +157,7 @@ class Task(RichRenderable, Generic[P, R]):
         print(f"Future {future} returned {result}")
     ```
     """
-    on_exception: Subscriber[Future[R], BaseException]
+    on_exception: Subscriber[[Future[R], BaseException], Any]
     """Called when a task failed to return anything but an exception.
     Comes with Future
     ```python
@@ -168,12 +167,12 @@ class Task(RichRenderable, Generic[P, R]):
     ```
     """
 
-    SUBMITTED: Event[Concatenate[Future[R], P]] = Event("on_submitted")
-    DONE: Event[Future[R]] = Event("on_done")
+    SUBMITTED: Event[Concatenate[Future[R], P], Any] = Event("on-submitted")
+    DONE: Event[[Future[R]], Any] = Event("on-done")
 
-    CANCELLED: Event[Future[R]] = Event("on_cancelled")
-    RESULT: Event[Future[R], R] = Event("on_result")
-    EXCEPTION: Event[Future[R], BaseException] = Event("on_exception")
+    CANCELLED: Event[[Future[R]], Any] = Event("on-cancelled")
+    RESULT: Event[[Future[R], R], Any] = Event("on-result")
+    EXCEPTION: Event[[Future[R], BaseException], Any] = Event("on-exception")
 
     def __init__(
         self: Self,
@@ -191,11 +190,7 @@ class Task(RichRenderable, Generic[P, R]):
             plugins: The plugins to use for this task.
             init_plugins: Whether to initialize the plugins or not.
         """
-        super().__init__()
-        self.unique_ref = randuid(8)
-
-        self.emitter = Emitter()
-        self.event_counts = self.emitter.event_counts
+        super().__init__(name=f"Task-{funcname(function)}")
         self.plugins: list[Plugin] = (
             [plugins] if isinstance(plugins, Plugin) else list(plugins)
         )
@@ -205,11 +200,11 @@ class Task(RichRenderable, Generic[P, R]):
         self.queue: list[Future[R]] = []
 
         # Set up subscription methods to events
-        self.on_submitted = self.emitter.subscriber(self.SUBMITTED)
-        self.on_done = self.emitter.subscriber(self.DONE)
-        self.on_result = self.emitter.subscriber(self.RESULT)
-        self.on_exception = self.emitter.subscriber(self.EXCEPTION)
-        self.on_cancelled = self.emitter.subscriber(self.CANCELLED)
+        self.on_submitted = self.subscriber(self.SUBMITTED)
+        self.on_done = self.subscriber(self.DONE)
+        self.on_result = self.subscriber(self.RESULT)
+        self.on_exception = self.subscriber(self.EXCEPTION)
+        self.on_cancelled = self.subscriber(self.CANCELLED)
 
         if init_plugins:
             for plugin in self.plugins:
@@ -222,97 +217,6 @@ class Task(RichRenderable, Generic[P, R]):
             A list of futures for this task.
         """
         return self.queue
-
-    @overload
-    def on(
-        self,
-        event: Event[P2],
-        callback: None = None,
-        *,
-        when: Callable[[], bool] | None = ...,
-        max_calls: int | None = ...,
-        repeat: int = ...,
-        every: int = ...,
-    ) -> Subscriber[P2]:
-        ...
-
-    @overload
-    def on(
-        self,
-        event: str,
-        callback: None = None,
-        *,
-        when: Callable[[], bool] | None = ...,
-        max_calls: int | None = ...,
-        repeat: int = ...,
-        every: int = ...,
-    ) -> Subscriber[...]:
-        ...
-
-    @overload
-    def on(
-        self,
-        event: str,
-        callback: Callable,
-        *,
-        when: Callable[[], bool] | None = ...,
-        max_calls: int | None = ...,
-        repeat: int = ...,
-        every: int = ...,
-    ) -> None:
-        ...
-
-    def on(
-        self,
-        event: Event[P2] | str,
-        callback: Callable[P2, Any] | None = None,
-        *,
-        when: Callable[[], bool] | None = None,
-        max_calls: int | None = None,
-        repeat: int = 1,
-        every: int = 1,
-        hidden: bool = False,
-    ) -> Subscriber[P2] | Subscriber[...] | None:
-        """Subscribe to an event.
-
-        Args:
-            event: The event to subscribe to.
-            callback: The callback to call when the event is emitted.
-                If not specified, what is returned can be used as a decorator.
-            when: A predicate to determine whether to call the callback.
-            max_calls: The maximum number of times to call the callback.
-            repeat: The number of times to repeat the subscription.
-            every: The number of times to wait between repeats.
-            hidden: Whether to hide the callback in visual output.
-                This is mainly used to facilitate Plugins who
-                act upon events but don't want to be seen, primarily
-                as they are just book-keeping callbacks.
-
-        Returns:
-            The subscriber if no callback was provided, otherwise `None`.
-        """
-        if isinstance(event, str):
-            _e = first_true(self.emitter.events, None, lambda e: e.name == event)
-            if _e is None:
-                raise EventNotKnownError(
-                    f"{event=} is not a valid event."
-                    f"\nKnown events are: {[e.name for e in self.emitter.events]}",
-                )
-        else:
-            _e = event
-
-        subscriber = self.emitter.subscriber(
-            _e,  # type: ignore
-            when=when,
-            max_calls=max_calls,
-            repeat=repeat,
-            every=every,
-        )
-        if callback is None:
-            return subscriber
-
-        subscriber(callback, hidden=hidden)
-        return None
 
     @property
     def n_running(self) -> int:
@@ -370,6 +274,10 @@ class Task(RichRenderable, Generic[P, R]):
         # original function name.
         msg = f"Submitted {callstring(self.function, *args, **kwargs)} from {self}."
         logger.debug(msg)
+
+        # NOTE: Not sure I like this approach but I don't see any direct harm.
+        # It should just provide more information to those listening to the callback
+        # which is mostly internal tooling such as the Comm Plugin
         self.on_submitted.emit(future, *args, **kwargs)
 
         # Process the task once it's completed
@@ -377,27 +285,6 @@ class Task(RichRenderable, Generic[P, R]):
         # this will immediatly call `self._process_future`.
         future.add_done_callback(self._process_future)
         return future
-
-    def copy(self, *, init_plugins: bool = True) -> Self:
-        """Create a copy of this task.
-
-        Will use the same scheduler and function, but will have a different
-        event manager such that any events listend to on the old task will
-        **not** trigger with the copied task.
-
-        Args:
-            init_plugins: Whether to initialize the copied plugins on the copied
-                task. Usually you will want to leave this as `True`.
-
-        Returns:
-            A copy of this task.
-        """
-        return self.__class__(
-            self.function,
-            self.scheduler,
-            plugins=tuple(p.copy() for p in self.plugins),
-            init_plugins=init_plugins,
-        )
 
     def _process_future(self, future: Future[R]) -> None:
         try:
@@ -464,7 +351,7 @@ class Task(RichRenderable, Generic[P, R]):
                 items.append(plugin)
 
         tree = Tree(label="", hide_root=True)
-        tree.add(self.emitter)
+        tree.add(self)
         items.append(tree)
 
         return Panel(

--- a/src/amltk/scheduling/task.py
+++ b/src/amltk/scheduling/task.py
@@ -275,9 +275,6 @@ class Task(Emitter, RichRenderable, Generic[P, R]):
         msg = f"Submitted {callstring(self.function, *args, **kwargs)} from {self}."
         logger.debug(msg)
 
-        # NOTE: Not sure I like this approach but I don't see any direct harm.
-        # It should just provide more information to those listening to the callback
-        # which is mostly internal tooling such as the Comm Plugin
         self.on_submitted.emit(future, *args, **kwargs)
 
         # Process the task once it's completed

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -651,7 +651,7 @@ def cross_validate_task(  # noqa: D103, C901, PLR0915, PLR0913
                             raise CVEarlyStoppedError("Early stopped!")
                         case False:
                             pass
-                        case np.bool_ if bool(response) is True:
+                        case np.bool_() if bool(response) is True:
                             raise CVEarlyStoppedError("Early stopped!")
                         case Exception():
                             raise response

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -651,8 +651,9 @@ def cross_validate_task(  # noqa: D103, C901, PLR0915, PLR0913
                             raise CVEarlyStoppedError("Early stopped!")
                         case False:
                             pass
-                        case np.bool_() if bool(response) is True:
-                            raise CVEarlyStoppedError("Early stopped!")
+                        case np.bool_():
+                            if bool(response) is True:
+                                raise CVEarlyStoppedError("Early stopped!")
                         case Exception():
                             raise response
                         case _:

--- a/src/amltk/sklearn/evaluation.py
+++ b/src/amltk/sklearn/evaluation.py
@@ -67,7 +67,6 @@ from amltk.exceptions import (
     MismatchedTaskTypeWarning,
     TrialError,
 )
-from amltk.optimization.evaluation import EvaluationProtocol
 from amltk.profiling.profiler import Profiler
 from amltk.scheduling import Plugin, Task
 from amltk.scheduling.events import Emitter, Event
@@ -692,7 +691,7 @@ def cross_validate_task(  # noqa: D103, C901, PLR0915, PLR0913
             return trial.success(**metrics_to_report)
 
 
-class CVEvaluation(Emitter, EvaluationProtocol):
+class CVEvaluation(Emitter):
     """Cross-validation evaluation protocol.
 
     This protocol will create a cross-validation task to be used in parallel and
@@ -736,7 +735,7 @@ class CVEvaluation(Emitter, EvaluationProtocol):
     )
 
     history = pipeline.optimize(
-        target=evaluator,
+        target=evaluator.fn,
         metric=Metric("accuracy", minimize=False, bounds=(0, 1)),
         working_dir=working_dir,
         max_trials=1,
@@ -784,7 +783,7 @@ class CVEvaluation(Emitter, EvaluationProtocol):
         params={"configure": {"n_jobs": 2}}
     )
     history = pipeline.optimize(
-        target=evaluator,
+        target=evaluator.fn,
         metric=Metric("accuracy"),
         working_dir=working_dir,
         max_trials=1,
@@ -792,6 +791,12 @@ class CVEvaluation(Emitter, EvaluationProtocol):
     print(history.df())
     evaluator.bucket.rmdir()  # Cleanup
     ```
+
+    !!! tip "CV Early Stopping"
+
+        To see more about early stopping, please see
+        [`CVEvaluation.cv_early_stopping_plugin()`][amltk.sklearn.evaluation.CVEvaluation.cv_early_stopping_plugin].
+
     """
 
     FOLD_EVALUATED: Event[[FoldInfo], bool | Exception] = Event("fold-evaluated")

--- a/tests/scheduling/plugins/test_comm_plugin.py
+++ b/tests/scheduling/plugins/test_comm_plugin.py
@@ -18,19 +18,20 @@ from amltk.scheduling.plugins import Comm
 logger = logging.getLogger(__name__)
 
 
-def sending_worker(comm: Comm, replies: list[Any]) -> None:
+def sending_worker(replies: list[Any], *, comm: Comm | None = None) -> None:
     """A worker that responds to messages.
 
     Args:
         comm: The communication channel to use.
         replies: A list of replies to send to the client.
     """
+    assert comm is not None
     with comm.open():
         for reply in replies:
             comm.send(reply)
 
 
-def requesting_worker(comm: Comm, requests: list[Any]) -> None:
+def requesting_worker(requests: list[Any], *, comm: Comm | None = None) -> None:
     """A worker that waits for messages.
 
     This will send a request, waiting for a response, finally
@@ -41,6 +42,7 @@ def requesting_worker(comm: Comm, requests: list[Any]) -> None:
         comm: The communication channel to use.
         requests: A list of requests to receive from the client.
     """
+    assert comm is not None
     with comm.open():
         for request in requests:
             response = comm.request(request)

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -386,21 +386,21 @@ def test_evaluator(
     ]
     for metric_name in expected_summary_scorers:
         for i in range(n_splits):
-            assert f"fold_{i}:{metric_name}" in report.summary
+            assert f"split_{i}:{metric_name}" in report.summary
         assert f"mean_{metric_name}" in report.summary
         assert f"std_{metric_name}" in report.summary
 
     if train_score:
         for metric_name in expected_summary_scorers:
             for i in range(n_splits):
-                assert f"fold_{i}:train_{metric_name}" in report.summary
+                assert f"split_{i}:train_{metric_name}" in report.summary
             assert f"train_mean_{metric_name}" in report.summary
             assert f"train_std_{metric_name}" in report.summary
 
     # All folds are profiled
     assert "cv" in report.profiles
     for i in range(n_splits):
-        assert f"cv:fold_{i}" in report.profiles
+        assert f"cv:split_{i}" in report.profiles
 
 
 @parametrize(
@@ -815,5 +815,5 @@ def test_early_stopping_plugin(tmp_path: Path) -> None:
     assert "Early stop" in str(report.exception)
 
     # Only the first fold should have been run and put in summary
-    assert "fold_0:accuracy" in report.summary
-    assert "fold_1:accuracy" not in report.summary
+    assert "split_0:accuracy" in report.summary
+    assert "split_1:accuracy" not in report.summary

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -794,7 +794,7 @@ def test_early_stopping_plugin(tmp_path: Path) -> None:
         def update(self, report: Trial.Report) -> None:
             pass  # Normally you would update w.r.t. a finished trial
 
-        def should_stop(self, info: CVEvaluation.FoldInfo) -> bool:  # noqa: ARG002
+        def should_stop(self, info: CVEvaluation.SplitInfo) -> bool:  # noqa: ARG002
             # Just say yes, should stop
             return True
 

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -685,6 +685,14 @@ def test_evaluator_with_clustering(tmp_path: Path) -> None:
     assert report.values["adjusted_rand_score"] == pytest.approx(1.0)
 
 
+@pytest.mark.xfail(
+    reason=(
+        "This was a bug introduced by sklearn. If this fails, "
+        " it can be safely ignored for now. If it starts to work"
+        " on the action runners, please remove this xfail."
+        " See https://github.com/scikit-learn/scikit-learn/pull/28371"
+    ),
+)
 def test_custom_configure_gets_forwarded(tmp_path: Path) -> None:
     with sklearn_config_context(enable_metadata_routing=True):
         # Pipeline requests a max_depth, defaulting to 1
@@ -752,6 +760,14 @@ def _my_custom_builder(
     )
 
 
+@pytest.mark.xfail(
+    reason=(
+        "This was a bug introduced by sklearn. If this fails, "
+        " it can be safely ignored for now. If it starts to work"
+        " on the action runners, please remove this xfail."
+        " See https://github.com/scikit-learn/scikit-learn/pull/28371"
+    ),
+)
 def test_custom_builder_can_be_forwarded(tmp_path: Path) -> None:
     with sklearn_config_context(enable_metadata_routing=True):
         pipeline = Component(DecisionTreeClassifier, config={"max_depth": 1})

--- a/tests/sklearn/test_evaluation.py
+++ b/tests/sklearn/test_evaluation.py
@@ -685,14 +685,6 @@ def test_evaluator_with_clustering(tmp_path: Path) -> None:
     assert report.values["adjusted_rand_score"] == pytest.approx(1.0)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "This was a bug introduced by sklearn. If this fails, "
-        " it can be safely ignored for now. If it starts to work"
-        " on the action runners, please remove this xfail."
-        " See https://github.com/scikit-learn/scikit-learn/pull/28371"
-    ),
-)
 def test_custom_configure_gets_forwarded(tmp_path: Path) -> None:
     with sklearn_config_context(enable_metadata_routing=True):
         # Pipeline requests a max_depth, defaulting to 1
@@ -760,14 +752,6 @@ def _my_custom_builder(
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "This was a bug introduced by sklearn. If this fails, "
-        " it can be safely ignored for now. If it starts to work"
-        " on the action runners, please remove this xfail."
-        " See https://github.com/scikit-learn/scikit-learn/pull/28371"
-    ),
-)
 def test_custom_builder_can_be_forwarded(tmp_path: Path) -> None:
     with sklearn_config_context(enable_metadata_routing=True):
         pipeline = Component(DecisionTreeClassifier, config={"max_depth": 1})
@@ -820,6 +804,7 @@ def test_early_stopping_plugin(tmp_path: Path) -> None:
         working_dir=tmp_path,
         plugins=[evaluator.cv_early_stopping_plugin(strategy=CVEarlyStopper())],
         max_trials=1,
+        on_trial_exception="continue",
     )
     assert len(history) == 1
     report = history.reports[0]


### PR DESCRIPTION
Alright, another big one.

Major feature was to implement CVEarlyStopping. This will need to be documented once the optimization documentation gets updated. There also needs to be some default variants select-able by keyword but for now that's the subject of experimentation.

---

```python
class CVEarlyStopper:
    def __init__(self, metric: Metric, threshold: float):
        super().__init__()
        self.threshold = threshold
        self.metric = metric
        
    def update(self, report: Trial.Report) -> None:
        pass # Normally you would update w.r.t. a finished trial

    def should_stop(self, info: CVEvaluation.FoldInfo) -> bool:
        return info.scores[self.metric.name] < self.threshold
        
metric = Metric("accuracy", minimize=False)
evaluator = CVEvaluation(_X, _y)
early_stopper = CVEarlyStopper(metric=metric, threshold=0.8)

history = mlp_classifier.optimize(
    target=evaluator.fn,
    metric=metric,
    on_trial_exception="continue",  # Seems required to prevent early stopping raising
    
	# The primary job of the plugin is to establish a comm link between the worker and
	# the master process and use the class above to handle what to do.
   	plugins=[evaluator.cv_early_stopping_plugin(strategy=early_stopper)]
)
```

---

There were some larger updates that needed to be done to enable this, namely:
* This is implemented as a `Comm.Plugin` such that the worker process can communicate with the main process, where the `CVEarlyStopper` lives.
* The communication through `Comm` relies on the worker `request()`'ing whether it should stop and the main process `msg.respond(should_stop)`'ing on what to do.
* To shield the user from having to know about the details of how this is implemented, we would rather they implement a simple function and use it's return value to handle all of this.

To illustrate the more explicit callback method, the above way of doing things is more or less equivalent to the following:


```python
scheduler = Scheduler.with_processes(1)
evaluator = CVEvaluation(_X, _y)
metric = Metric("accuracy", minimize=False)

# Notably **nothing** passed in to `cv_early_stopping_plugin()` now, nothing will
# get called if we don't listen to the `@fold-evaluated` event.
task = scheduler.task(evaluator.fn, plugins=[evaluator.cv_early_stopping_plugin())

# Method one, listen to the `@fold-evaluated` callback and return what to do

@task.on("fold-evaluated")
def should_stop(self, info: CVEvaluation.FoldInfo) -> bool:
    return info.scores[metric.name] < 0.8
    
# Method two, this explicitly uses the `Comm` and `Msg` that happens underneath the hood.
# This is what `cv_early_stopping_plugin` is doing using the users object.

@task.on("comm-request")
def should_stop_2(msg: Msg.Data) -> None:
    fold_info: CVEvaluation.FoldInfo = msg.data
    if info.scores[metric.name] < 0.8:
        msg.respond(True)
    else:
    	msg.respond(False) 


history = mlp_classifier.optimize(
    target=task,
    metric=metric,
    on_trial_exception="continue",
    scheduler=scheduler,
)
```

The notable change was that the callback of `@task.on("fold-evaluated")` returned a value, shielding the user from the `Comm` implementation detail. This required updating the `Event` system to allow for returned values from handlers, necessitating the updated signature of **all** existing events in amltk. Hence a lot of changes.

---

Last few changes were around code simplification while I was going through implementing this.
* The concept of an `Evaluator` as something more than just a callable function was removed as there was little benefit seen while implementing this. It would help us shove more behavior into `pipeline.optimize` but for now, we should not hide people from the other parts of AMLTK which provides a lot more utility and customization, not afforded by just parameters to a function. _(Maybe we revisit this at some point but it helps reduce maint. complexity)_

* The `@events` for the `Scheduler` and `Task` all had strings such as `"on_result"` while things like the `Comm.Plugin` had events like `"comm-message"`. These were unified more to use hyphens (`"-"`) and to remove the `"on"` part such that user code reads nicer.

```python
# Before
@task.on("on_result")
def f(...): ...

@task.on("on_future_submitted")
def f(...): ...

# After
@task.on("result")
def f(...): ...

@task.on("future-submitted")
def f(...): ...

# Note comm message using hyphens
@task.on("comm-message")
def f(...): ...
```

This is backwards breaking, but given we advertise using `task.on_result` as a shorthand that should work the same, I'm okay with making the breaking change sooner rather than later. I think we should still advertise the `on_<event>` where it's possible as it provides a level of type safety we just can't do with strings.

* The requirement of `copy()` for plugins is hard to meet for stateful plugins. While nice in principal, this was all done to support `task.copy()`. In all my use of the library so far, I've never once needed this feature. Remove for now.




* `Metric.compare(v1, v2)` for knowing if a value is `Metric.Comparison.EQUAL/WORSE/BETTER` to not have to constantly check if a metric is minimize or not. This also allows match statements which are a bit more explicit in terms of behaviour routing and allow us to recommend this as public API for a `Metric`, hiding details behind curtains.

