### PR TITLE
fix: precommit issues from #276

### DIFF
--- a/examples/pytorch-example.py
+++ b/examples/pytorch-example.py
@@ -16,12 +16,7 @@ from torch import nn, optim
 from torch.optim.lr_scheduler import StepLR
 from torchvision import datasets, transforms
 
-from amltk import (
-    Choice,
-    Component,
-    Metric,
-    Sequential,
-)
+from amltk import Choice, Component, Metric, Sequential
 from amltk.optimization.optimizers.smac import SMACOptimizer
 from amltk.pytorch import (
     MatchChosenDimensions,
@@ -54,8 +49,8 @@ def test(
     test_loss = 0.0
     correct = 0.0
     with torch.no_grad():
-        for test_data, test_target in test_loader:
-            test_data, test_target = test_data.to(device), test_target.to(device)
+        for _test_data, _test_target in test_loader:
+            test_data, test_target = _test_data.to(device), _test_target.to(device)
             output = model(test_data)
             test_loss += f.nll_loss(output, test_target, reduction="sum").item()
             pred = output.argmax(dim=1, keepdim=True)
@@ -136,9 +131,9 @@ def eval_configuration(
         lr_scheduler = StepLR(optimizer, step_size=1, gamma=gamma)
 
         for epoch in range(epochs):
-            for batch_idx, (data, target) in enumerate(train_loader):
+            for batch_idx, (_data, _target) in enumerate(train_loader):
                 optimizer.zero_grad()
-                data, target = data.to(_device), target.to(_device)
+                data, target = _data.to(_device), _target.to(_device)
 
                 output = model(data)
                 loss = f.nll_loss(output, target)

--- a/src/amltk/pytorch/builders.py
+++ b/src/amltk/pytorch/builders.py
@@ -5,6 +5,8 @@ It also includes classes for handling dimension matching between layers.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from torch import nn
@@ -13,6 +15,7 @@ from amltk import Choice, Fixed, Node
 from amltk.exceptions import MatchChosenDimensionsError, MatchDimensionsError
 
 
+@dataclass
 class MatchDimensions:
     """Handles matching dimensions between layers in a pipeline.
 
@@ -21,21 +24,13 @@ class MatchDimensions:
     and stores them for later reference.
 
     Not intended to be used inside a Choice node.
-
-    Attributes:
-        layer_name (str): The name of the layer.
-        param (str | None): The name of the parameter.
     """
 
-    def __init__(self, layer_name: str, param: str | None) -> None:
-        """Initializes the MatchDimensions object.
+    layer_name: str
+    """The name of the layer."""
 
-        Args:
-            layer_name (str): The name of the layer.
-            param (str | None): The name of the parameter.
-        """
-        self.layer_name = layer_name
-        self.param = param
+    param: str
+    """The name of the parameter to match."""
 
     def evaluate(self, pipeline: Node) -> int:
         """Retrieves the corresponding configuration value from the pipeline.
@@ -56,6 +51,7 @@ class MatchDimensions:
         return value
 
 
+@dataclass
 class MatchChosenDimensions:
     """Handles matching dimensions for chosen nodes in a pipeline.
 
@@ -63,22 +59,15 @@ class MatchChosenDimensions:
     during HPO optimization. It takes the choice name and the corresponding
     dimensions for that choice and stores them for later reference.
 
-    Attributes:
-        choice_name (str): The name of the choice.
-        choices (dict): A dictionary containing dimensions for choices.
     """
 
-    def __init__(self, choice_name: str, choices: dict) -> None:
-        """Initializes the MatchChosenDimensions object.
+    choice_name: str
+    """The name of the choice node."""
 
-        Args:
-            choice_name (str): The name of the choice.
-            choices (dict): A dictionary containing dimensions for choices.
-        """
-        self.choice_name = choice_name
-        self.choices = choices
+    choices: Mapping[str, Any]
+    """The mapping of choice taken to the dimension to use."""
 
-    def evaluate(self, chosen_nodes: dict[str, Any]) -> int:
+    def evaluate(self, chosen_nodes: dict[str, str]) -> int:
         """Retrieves the corresponding dimension for the chosen node.
 
         If the chosen node is not found in the choices dictionary, an error is raised.

--- a/src/amltk/pytorch/builders.py
+++ b/src/amltk/pytorch/builders.py
@@ -80,7 +80,10 @@ class MatchChosenDimensions:
         Returns:
             The value of the matching dimension for a chosen node.
         """
-        chosen_node_name = chosen_nodes.get(self.choice_name)
+        chosen_node_name = chosen_nodes.get(self.choice_name, None)
+
+        if chosen_node_name is None:
+            raise MatchChosenDimensionsError(self.choice_name, chosen_node_name=None)
 
         try:
             return self.choices[chosen_node_name]

--- a/tests/pytorch/test_match_dimensions.py
+++ b/tests/pytorch/test_match_dimensions.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 import pytest
 import torch
 
-from amltk import (
-    Component,
-    Fixed,
-    Node,
-    Sequential,
-)
+from amltk import Component, Fixed, Node, Sequential
 from amltk.exceptions import MatchDimensionsError
 from amltk.pytorch import MatchDimensions, build_model_from_pipeline
 from tests.pytorch.common import create_optimizer
@@ -49,11 +44,11 @@ class TestMatchDimensions:
         params=[
             MatchDimensions("non-existing-layer", param="out_features"),
             MatchDimensions("fc1", param="non-existing-param"),
-            MatchDimensions("fc1", param=None),
+            MatchDimensions("fc1", param=None),  # type: ignore
             MatchDimensions(layer_name="", param="out_features"),
         ],
     )
-    def invalid_pipeline(self, request) -> Node:
+    def invalid_pipeline(self, request: pytest.FixtureRequest) -> Node:
         """Fixture to create several invalid pipelines."""
         return Sequential(
             torch.nn.Flatten(start_dim=1),


### PR DESCRIPTION
* Fixes pre-commit errors
* Convert `MatchXXX` to simple dataclasses
* Fix some small issues with respect to typing
* Refactor to use `match` statements

---

The motivation behind `match` is it lets the type checker know a bit more about what you want to do, i.e. exhaustively handling of cases. When using `if` statements, if you forget an `else`, it won't complain, however when using a `match` statement, it says you haven't handled all cases.

```python
node: Node
match node:  # Error: You havn't exhaustively handled all cases
    case Component():
        pass
    case Fixed():
        pass
        
#####
node: Node
if isinstance(node, Component):
    pass
elif isistnance(node, Fixed):
    pass
# Type checker says this is all fine
```