### PR TITLE
ci: Remove unnecessary Python setup step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: 1  # Essential to later commitizen
-          fetch-depth: 0  # Reccommended by the action
+          fetch-depth: 0  # Recommended by the action
           token: ${{ secrets.PUSH_ACCESS }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: pip
       - run: git tag  # Debug statement
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master


### PR DESCRIPTION
#### Reference Issues/PRs

I could've opened a separate issue, but I figured a PR makes it easier to view my suggestion.

#### What does this implement/fix? Explain your changes.

When looking at this workflow I noticed that there seems to be an extraneous Python setup step in the citizen bump job. As far as I can tell, it serves no purpose. In my work-in-progress workflow I left it out without issue.

#### Minimal Example / How should this PR be tested?

Run the workflow (on a fork where it is not a trusted PyPI publisher...). I tried it [here](https://github.com/PGijsbers/amltk/actions/runs/9197051255/job/25296590574), but unfortunately the docs step already seems to be failing, so it won't show a successful bump. So that step would need to be resolved first, but it's unrelated to this PR. After that, you _should_ see that indeed the Python setup step is not necessary to execute the bump job and you can release [23 seconds](https://github.com/automl/amltk/actions/runs/8817754947/job/24205615913) faster. Nifty.

#### Any other comments?

Made the change from the browser, so it did bypass pre-commit. I assume there is a pre-commit CI running so that if there's a problem it'll be detected before a merge anyway.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.